### PR TITLE
Adjust font sizes

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "sass": "^1.32.0",
     "sass-loader": "^10.1.0",
     "speed-measure-webpack-plugin": "^1.3.3",
-    "vue-cli-plugin-vuetify": "2.0.6",
+    "vue-cli-plugin-vuetify": "2.0.9",
     "vue-loader": "15.9.4",
     "vue-template-compiler": "2.6.12",
     "vuetify-loader": "1.6.0",

--- a/src/main.js
+++ b/src/main.js
@@ -1,12 +1,12 @@
-import Vue from 'vue'
-import App from './App'
-import vuetify from './plugins/vuetify';
-import 'vuetify/dist/vuetify.min.css'
+import Vue from "vue";
+import App from "./App";
+import vuetify from "./plugins/vuetify";
+// import 'vuetify/dist/vuetify.min.css'
 
 /* eslint-disable no-new */
 new Vue({
   vuetify,
-  el: '#app',
+  el: "#app",
   components: { App },
-  render: h => h(App)
-})
+  render: h => h(App),
+});

--- a/src/sass/variables.scss
+++ b/src/sass/variables.scss
@@ -1,0 +1,84 @@
+// src/sass/variables.scss
+
+// Globals
+// $body-font-family: 'Comic Sans MS', serif;
+// $header-font-family: 'Comic Sans MS', serif;
+$border-radius-root: 6px;
+$font-size-root: 14px;
+
+// Variables must come before the import
+$btn-letter-spacing: 0;
+$btn-font-weight: 400;
+$btn-sizes: (
+  "default": 38,
+  "large": 51,
+);
+$fab-sizes: (
+  "default": 54,
+  "large": 62,
+);
+$fab-icon-sizes: (
+  "small": 20,
+  "default": 22,
+);
+
+$list-item-title-font-size: 0.929rem;
+$list-item-dense-title-font-size: 0.929rem;
+$list-item-dense-title-font-weight: initial;
+
+//Rewrite all the headings
+$headings: (
+  "h1": (
+    "size": 3.3125rem,
+    "line-height": 1.15em,
+  ),
+  "h2": (
+    "size": 2.25rem,
+    "line-height": 1.5em,
+  ),
+  "h3": (
+    "size": 1.9rem,
+    "line-height": 1.2em,
+  ),
+  // "h4": (
+  //   "size": 1.275rem,
+  //   "line-height": 1em,
+  // ),
+  // "h5": (
+  //   "size": 0.9rem,
+  //   "line-height": 1em,
+  // ),
+  // "h6": (
+  //   "size": 0.75rem,
+  //   "line-height": 1em,
+  // ),
+);
+
+$icon-sizes: (
+  "x-small": (
+    "font-size": 8,
+    "height": 14,
+  ),
+  "small": (
+    "font-size": 10,
+    "height": 22,
+  ),
+  "default": (
+    "font-size": 12,
+    "height": 30,
+  ),
+  "large": (
+    "font-size": 14,
+    "height": 52,
+  ),
+  "x-large": (
+    "font-size": 16,
+    "height": 64,
+  ),
+);
+
+.v-input .v-label {
+  font-size: 14px;
+}
+
+@import "~vuetify/src/styles/styles.sass";

--- a/src/sass/variables.scss
+++ b/src/sass/variables.scss
@@ -1,8 +1,6 @@
 // src/sass/variables.scss
 
 // Globals
-// $body-font-family: 'Comic Sans MS', serif;
-// $header-font-family: 'Comic Sans MS', serif;
 $border-radius-root: 6px;
 $font-size-root: 14px;
 
@@ -40,18 +38,6 @@ $headings: (
     "size": 1.9rem,
     "line-height": 1.2em,
   ),
-  // "h4": (
-  //   "size": 1.275rem,
-  //   "line-height": 1em,
-  // ),
-  // "h5": (
-  //   "size": 0.9rem,
-  //   "line-height": 1em,
-  // ),
-  // "h6": (
-  //   "size": 0.75rem,
-  //   "line-height": 1em,
-  // ),
 );
 
 $icon-sizes: (

--- a/yarn.lock
+++ b/yarn.lock
@@ -10354,6 +10354,14 @@ nth-check@^1.0.2, nth-check@~1.0.1:
   dependencies:
     boolbase "~1.0.0"
 
+null-loader@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-3.0.0.tgz#3e2b6c663c5bda8c73a54357d8fa0708dc61b245"
+  integrity sha512-hf5sNLl8xdRho4UPBOOeoIwT3WhjYcMUQm0zj44EhD6UscMAz72o2udpoDFBgykucdEDGIcd6SXbc/G6zssbzw==
+  dependencies:
+    loader-utils "^1.2.3"
+    schema-utils "^1.0.0"
+
 num2fraction@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/num2fraction/-/num2fraction-1.2.2.tgz#6f682b6a027a4e9ddfa4564cd2589d1d4e669ede"
@@ -14054,11 +14062,12 @@ vue-cli-plugin-apollo@^0.21.3:
     subscriptions-transport-ws "^0.9.16"
     ts-node "^8.4.1"
 
-vue-cli-plugin-vuetify@2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/vue-cli-plugin-vuetify/-/vue-cli-plugin-vuetify-2.0.6.tgz#910f996a5c07e9f4e651bb332992cd0868e08546"
-  integrity sha512-Y0VEK7gJTPW+LcSXBO8bx0YWzMoKMYHqcLpGF1EomGfAQrZafSulCZXcqF6++H4cPjFRkqB/YJ2xN/rTiu0DeA==
+vue-cli-plugin-vuetify@2.0.9:
+  version "2.0.9"
+  resolved "https://registry.yarnpkg.com/vue-cli-plugin-vuetify/-/vue-cli-plugin-vuetify-2.0.9.tgz#982991aec28e79d1f0c2eb8f6e3d62e042087ee8"
+  integrity sha512-J4fzpz27OmCCAA3CI56ulYsUrZ859dQAh58Z9XZilY03kd/M+svLlPkK45cBIrGGfjSqQ40oyWezA3NiPBEG8g==
   dependencies:
+    null-loader "^3.0.0"
     semver "^7.1.2"
     shelljs "^0.8.3"
 


### PR DESCRIPTION
This PR adjusts several styles for `IFXVue` components. These include:

- base and header font sizes shrunk
- Some headers reduced
- Buttons shrunk somewhat

Note that not all headers have been adjusted and the font itself hasn't been changed.

This required updating the `vue-cli-plugin-vuetify` plugin to something greater than 2.0.6 as that fixed a bug where it would use an invalid option with `sass-loader` 9 or above.