### PR TITLE
Strict token

### DIFF
--- a/src/api/IFXAPI.js
+++ b/src/api/IFXAPI.js
@@ -144,7 +144,7 @@ export default class IFXAPIService {
 
   get auth() {
     return {
-      headerValue: this.authUser ? `Token ${this.authUser.token}` : '',
+      headerValue: this.authUser && this.authUser.token ? `Token ${this.authUser.token}` : '',
       isAuthenticated: this.authUser ? this.authUser.isAuthenticated : false,
       isAdmin: this.authUser ? this.authUser.isAdmin : false,
       isStaff: this.authUser ? this.authUser.isStaff : false,


### PR DESCRIPTION
Only include the Token header if there is an authUser AND a token value.  The logout function resets authUser to an empty value which is truthy, so token must be checked.