### PR TITLE
Dda user detail redesign

### DIFF
--- a/src/api/IFXAPI.js
+++ b/src/api/IFXAPI.js
@@ -506,7 +506,12 @@ export default class IFXAPIService {
       // TODO: better way to handle this
       COLOR_FOR_GROUP: { Admin: '#fafad2' },
       colorForGroup(group) {
-        return group in this.COLOR_FOR_GROUP ? this.COLOR_FOR_GROUP[group] : 'efefef'
+        return group in this.COLOR_FOR_GROUP ? this.COLOR_FOR_GROUP[group] : '#efefef'
+      },
+      // TODO: better way to handle this
+      ICON_FOR_GROUP: { Admin: 'mdi-key' },
+      iconForGroup(group) {
+        return group in this.ICON_FOR_GROUP ? this.ICON_FOR_GROUP[group] : 'mdi-check-decagram'
       }
     }
   }

--- a/src/components/item/IFXItemHistoryDisplay.vue
+++ b/src/components/item/IFXItemHistoryDisplay.vue
@@ -1,10 +1,8 @@
 <template>
-  <v-row>
-    <v-col>
-      <span class='history-subtitle'>Updated: </span><span>{{updatedDate}}</span>
-    </v-col>
-    <v-col>
-      <span class='history-subtitle'>Created: </span><span>{{createdDate}}</span>
+  <v-row no-gutters>
+    <v-col class="d-flex flex-column">
+      <div><span class='text-subtitle font-weight-medium'>Updated on&nbsp;</span><span class="text-body-2">{{updatedDate}}</span></div>
+      <div><span class='text-subtitle font-weight-medium'>Created on&nbsp;</span><span class="text-body-2">{{createdDate}}</span></div>
     </v-col>
   </v-row>
 </template>

--- a/src/components/user/IFXUserDetail.vue
+++ b/src/components/user/IFXUserDetail.vue
@@ -57,7 +57,7 @@ export default {
         <v-col sm="7">
           <h3>Groups to which this user belongs</h3>
           <span v-if="item.groups" class="d-flex flex-column">
-            <div v-for="group in item.groups" :key="group" class="d-flex align-center">
+            <div v-for="group in item.groups" :key="group" class="d-flex align-center mt-1">
               <v-icon class="mr-1">{{$api.group.iconForGroup(group)}}</v-icon>
               <span>{{group}}</span>
             </div>

--- a/src/components/user/IFXUserDetail.vue
+++ b/src/components/user/IFXUserDetail.vue
@@ -33,7 +33,7 @@ export default {
 <template>
   <v-container v-if="!isLoading">
     <IFXPageHeader>
-      <template #title>{{detailTitle}} {{item.fullName || id}}</template>
+      <template #title>{{item.fullName || id}}<v-icon color="yellow darken-1" class="ml-2 mb-1 key-background" v-if="item.isAdmin">mdi-key</v-icon></template>
       <template #actions>
         <IFXLoginIcon disabled v-if='item.isActive !== undefined' :isActive='item.isActive'/>
         <IFXButton btnType="edit" @action="navigateToItemEdit(id)"/>
@@ -55,26 +55,14 @@ export default {
           <div class="data-item">{{item.primaryEmail}}</div>
         </v-col>
         <v-col sm="7">
-          <v-combobox
-            v-model="item.groups"
-            :items="allGroupNames"
-            disabled
-            multiple
-            solo
-            label='Groups'
-            hint='Groups to which this user belongs.'
-            persistent-hint
-          >
-            <template #selection="{item}">
-              <v-chip
-                :color="$api.group.colorForGroup(item)"
-                close
-                @click:close="removeGroup(item)"
-              >
-                <strong>{{ item }}</strong>
-              </v-chip>
-            </template>
-          </v-combobox>
+          <h3>Groups to which this user belongs</h3>
+          <span v-if="item.groups" class="d-flex flex-column">
+            <div v-for="group in item.groups" :key="group" class="d-flex align-center">
+              <v-icon class="mr-1">{{$api.group.iconForGroup(group)}}</v-icon>
+              <span>{{group}}</span>
+            </div>
+          </span>
+          <span v-else>None</span>
         </v-col>
       </v-row>
       <v-row>
@@ -118,5 +106,11 @@ export default {
   .data-item {
     padding-top: 1px;
     padding-bottom: 1px;
+  }
+
+  .key-background {
+    background-color: #90A4AE;
+    border-radius: 50%;
+    padding: 5px;
   }
 </style>

--- a/src/components/user/IFXUserDetail.vue
+++ b/src/components/user/IFXUserDetail.vue
@@ -33,7 +33,7 @@ export default {
 <template>
   <v-container v-if="!isLoading">
     <IFXPageHeader>
-      <template #title>{{detailTitle}}: {{item.username || id}}</template>
+      <template #title>{{detailTitle}} {{item.fullName || id}}</template>
       <template #actions>
         <IFXLoginIcon disabled v-if='item.isActive !== undefined' :isActive='item.isActive'/>
         <IFXButton btnType="edit" @action="navigateToItemEdit(id)"/>
@@ -42,34 +42,19 @@ export default {
         <IFXItemHistoryDisplay :item='item'/>
       </template>
     </IFXPageHeader>
-    <v-container px-5 py-0>
-      <v-row>
-        <v-col>
+    <v-container>
+      <v-row no-gutters>
+        <v-col sm="2">
           <h3>First Name</h3>
-          <p>{{item.firstName}}</p>
-        </v-col>
-        <v-col>
           <h3>Last Name</h3>
-          <p>{{item.lastName}}</p>
-        </v-col>
-        <v-col>
-          <h3>Username</h3>
-          <p>{{item.username}}</p>
-        </v-col>
-      </v-row>
-      <v-row>
-        <v-col>
-          <h3>IFXID</h3>
-          <p>{{item.ifxid}}</p>
-        </v-col>
-        <v-col>
           <h3>Primary Email</h3>
-          <p>{{item.primaryEmail}}</p>
         </v-col>
-        <v-spacer></v-spacer>
-      </v-row>
-      <v-row>
-        <v-col>
+        <v-col sm="3">
+          <div class="data-item">{{item.firstName}}</div>
+          <div class="data-item">{{item.lastName}}</div>
+          <div class="data-item">{{item.primaryEmail}}</div>
+        </v-col>
+        <v-col sm="7">
           <v-combobox
             v-model="item.groups"
             :items="allGroupNames"
@@ -91,6 +76,8 @@ export default {
             </template>
           </v-combobox>
         </v-col>
+      </v-row>
+      <v-row>
       </v-row>
       <v-row>
         <v-col>
@@ -127,5 +114,9 @@ export default {
     display: flex;
     justify-content: space-between;
     align-items: center;
+  }
+  .data-item {
+    padding-top: 1px;
+    padding-bottom: 1px;
   }
 </style>


### PR DESCRIPTION
This PR updates the layout of the User Detail page. It also adds icons to the full name (if they are admin) and each group to which they belong (right now, there is only a default icon but this can be overridden in an individual app).