### PR TITLE
User Edit page redesign

### DIFF
--- a/src/components/IFXButton.vue
+++ b/src/components/IFXButton.vue
@@ -75,8 +75,11 @@ export default {
         case 'remove':
           btnColor = 'red'
           break;
+        case 'reset':
+          btnColor = 'yellow'
+          break;
         case 'submit':
-          btnColor = 'secondary'
+          btnColor = 'primary'
           break;
         case 'close':
           btnColor = 'secondary'

--- a/src/components/contact/IFXSelectableContact.vue
+++ b/src/components/contact/IFXSelectableContact.vue
@@ -87,7 +87,6 @@ export default {
           <v-text-field
             v-model.trim="itemLocal.contact.detail"
             autocomplete="new-password"
-            return-masked-value
             :error-messages="errors['contacts.detail']"
             :rules="formRules.email"
             label="Email"
@@ -98,7 +97,6 @@ export default {
           <v-text-field
             v-model.trim="itemLocal.contact.phone"
             autocomplete="new-password"
-            return-masked-value
             :error-messages="errors['contacts.phone']"
             label="Phone"
           ></v-text-field>

--- a/src/components/user/IFXUserEdit.vue
+++ b/src/components/user/IFXUserEdit.vue
@@ -128,7 +128,8 @@ export default {
       this.closeDialog();
     },
     restore() {
-      this.item.data = clone(this.cachedItem.data)
+      // cachedItem isn't a User object so can't use .data
+      this.item.data = clone(this.cachedItem._data)
       this.clearAllErrors()
     },
     canEdit(field) {
@@ -172,7 +173,7 @@ export default {
         </template>
         </IFXPageHeader>
         <v-container v-if='hasIFXID'>
-          <v-row>
+          <v-row no-gutters>
             <v-col>
               <p>Use this form to view and edit user information.
                 Changes to most fields (except for application Groups) will update
@@ -182,7 +183,7 @@ export default {
           </v-row>
           <v-form @submit.prevent v-model="isValid" autocomplete="off" :ref="formName">
             <v-row>
-              <v-col>
+              <v-col sm="6">
                 <v-text-field
                   v-model.trim="item.firstName"
                   label="First name"
@@ -193,8 +194,8 @@ export default {
                   :rules="formRules.generic"
                   required
                 ></v-text-field>
-              </v-col>
-              <v-col>
+              <!-- </v-col>
+              <v-col sm="12"> -->
                 <v-text-field
                   v-model.trim="item.lastName"
                   label="Last name"
@@ -205,8 +206,8 @@ export default {
                   :rules="formRules.generic"
                   required
                 ></v-text-field>
-              </v-col>
-              <v-col>
+              <!-- </v-col>
+              <v-col sm="12"> -->
                 <v-text-field
                   v-model.trim="item.fullName"
                   label="Full name"
@@ -218,21 +219,7 @@ export default {
                   required
                 ></v-text-field>
               </v-col>
-            </v-row>
-            <v-row>
-              <v-col>
-                <v-text-field
-                  v-model.trim="item.primaryEmail"
-                  label="Primary Email"
-                  autocomplete="new-password"
-                  :error-messages="errors.primary_email"
-                  @focus="clearError('primary_email')"
-                  :disabled="!canEdit('User.primaryEmail')"
-                  :rules="formRules.email"
-                  required
-                ></v-text-field>
-              </v-col>
-              <v-col>
+              <v-col sm="6">
                 <v-combobox
                   v-if="canEdit('User.groups')"
                   v-model="item.groups"
@@ -260,7 +247,21 @@ export default {
               </v-col>
             </v-row>
             <v-row>
-              <v-col>
+              <v-col sm="6">
+                <v-text-field
+                  v-model.trim="item.primaryEmail"
+                  label="Primary Email"
+                  autocomplete="new-password"
+                  :error-messages="errors.primary_email"
+                  @focus="clearError('primary_email')"
+                  :disabled="!canEdit('User.primaryEmail')"
+                  :rules="formRules.email"
+                  required
+                ></v-text-field>
+              </v-col>
+            <!-- </v-row>
+            <v-row> -->
+              <v-col sm="6">
                 <v-text-field
                   label='Primary Affiliation'
                   :value='item.primaryAffiliation'
@@ -295,16 +296,17 @@ export default {
               </v-col>
             </v-row>
             <v-row>
-              <v-col>
+              <!-- <v-spacer></v-spacer> -->
+              <v-col class="d-flex justify-end">
                 <IFXButton
-                  btnType='submit'
-                  color='yellow'
+                  btnType='reset'
                   btnText='Reset'
                   @action='restore'
+                  class="mr-3"
                   :disabled='!hasItemChanged()'
                 ></IFXButton>
-              </v-col>
-              <v-col>
+              <!-- </v-col>
+              <v-col> -->
                 <IFXButton
                   btnType='submit'
                   @action='openDialog'

--- a/src/components/user/IFXUserEdit.vue
+++ b/src/components/user/IFXUserEdit.vue
@@ -194,8 +194,6 @@ export default {
                   :rules="formRules.generic"
                   required
                 ></v-text-field>
-              <!-- </v-col>
-              <v-col sm="12"> -->
                 <v-text-field
                   v-model.trim="item.lastName"
                   label="Last name"
@@ -206,8 +204,6 @@ export default {
                   :rules="formRules.generic"
                   required
                 ></v-text-field>
-              <!-- </v-col>
-              <v-col sm="12"> -->
                 <v-text-field
                   v-model.trim="item.fullName"
                   label="Full name"
@@ -259,8 +255,6 @@ export default {
                   required
                 ></v-text-field>
               </v-col>
-            <!-- </v-row>
-            <v-row> -->
               <v-col sm="6">
                 <v-text-field
                   label='Primary Affiliation'

--- a/src/components/user/IFXUserEdit.vue
+++ b/src/components/user/IFXUserEdit.vue
@@ -290,7 +290,6 @@ export default {
               </v-col>
             </v-row>
             <v-row>
-              <!-- <v-spacer></v-spacer> -->
               <v-col class="d-flex justify-end">
                 <IFXButton
                   btnType='reset'
@@ -299,8 +298,6 @@ export default {
                   class="mr-3"
                   :disabled='!hasItemChanged()'
                 ></IFXButton>
-              <!-- </v-col>
-              <v-col> -->
                 <IFXButton
                   btnType='submit'
                   @action='openDialog'


### PR DESCRIPTION
Despite the branch name, this PR re-lays out the User Edit page. It also makes some important changes to the default submit and reset buttons:

- The Submit button is now the primary color by default (blue)
- The Reset button is now a yellow color by default

