### PR TITLE
Fix issues required to make Cypress tests pass

### DIFF
--- a/src/api/IFXAPI.js
+++ b/src/api/IFXAPI.js
@@ -215,7 +215,7 @@ export default class IFXAPIService {
   }
 
   get contact() {
-    const baseUrl = this.urls.contact
+    const baseUrl = this.urls.CONTACTS
     const api = this.genericAPI(baseUrl, Contact)
     // TODO: this getList method is defined here because the url is different than the baseurl
     api.getList = async (params) => {

--- a/src/components/contact/IFXContactCreateEdit.vue
+++ b/src/components/contact/IFXContactCreateEdit.vue
@@ -43,6 +43,7 @@ export default {
             <v-text-field
               v-model='item.name'
               label='Name'
+              data-cy='name'
               :rules='formRules.generic'
               :error-messages='errors.name'
               required
@@ -52,6 +53,7 @@ export default {
             <v-text-field
               v-model='item.detail'
               label='Email'
+              data-cy='email'
               :rules='formRules.email'
               :error-messages='errors.detail'
               required
@@ -63,6 +65,7 @@ export default {
             <v-select
               v-model='item.type'
               label='Type'
+              data-cy='type'
               :items='apiRef.types'
               :rules='formRules.generic'
               :error-messages='errors.type'
@@ -74,6 +77,7 @@ export default {
               v-model='item.phone'
               label='Phone'
               type='number'
+              data-cy='phone'
               :rules='formRules.phone'
             >
             </v-text-field>
@@ -84,6 +88,7 @@ export default {
             <v-text-field
               v-model='item.address'
               label='Address'
+              data-cy='address'
             ></v-text-field>
           </v-col>
         </v-row>

--- a/src/components/contact/IFXContactDetail.vue
+++ b/src/components/contact/IFXContactDetail.vue
@@ -1,8 +1,8 @@
 <template>
   <v-container v-if='!isLoading'>
     <IFXPageHeader>
-      <template #title>{{itemType}} </template>
-      <template #id>{{id}}</template>
+      <template #title>{{itemType}} Card for {{item.name}}</template>
+      <template #cypress>{{id}}</template>
       <template #actions>
         <IFXButton btnType="edit" @action="navigateToItemEdit(id)"/>
       </template>

--- a/src/components/contact/IFXContactDetail.vue
+++ b/src/components/contact/IFXContactDetail.vue
@@ -5,6 +5,7 @@
       <template #cypress>{{id}}</template>
       <template #actions>
         <IFXButton btnType="edit" @action="navigateToItemEdit(id)"/>
+        <IFXDeleteItemButton :item='item' :apiRef='apiRef' :itemType='itemType'/>
       </template>
     </IFXPageHeader>
   <IFXContactCard :contact='item' :editBtn='false'/>
@@ -15,12 +16,14 @@
 import IFXContactCard from '@/components/contact/IFXContactCard'
 import IFXContactMixin from '@/components/contact/IFXContactMixin'
 import IFXItemDetailMixin from '@/components/item/IFXItemDetailMixin'
+import IFXDeleteItemButton from '@/components/item/IFXDeleteItemButton'
 
 export default {
   name: 'IFXContactDetail',
   mixins: [IFXContactMixin, IFXItemDetailMixin],
   components: {
-    IFXContactCard
+    IFXContactCard,
+    IFXDeleteItemButton
   }
 }
 </script>

--- a/src/components/contact/IFXContactDetail.vue
+++ b/src/components/contact/IFXContactDetail.vue
@@ -1,7 +1,8 @@
 <template>
   <v-container v-if='!isLoading'>
     <IFXPageHeader>
-      <template #title>{{itemType}}: {{id}}</template>
+      <template #title>{{itemType}} </template>
+      <template #id>{{id}}</template>
       <template #actions>
         <IFXButton btnType="edit" @action="navigateToItemEdit(id)"/>
       </template>

--- a/src/components/contact/IFXContactList.vue
+++ b/src/components/contact/IFXContactList.vue
@@ -52,6 +52,11 @@ export default {
   }
 }
 </script>
+<style lang="scss" scoped>
+.full-width {
+  width: 100%;
+}
+</style>
 <template>
   <v-container v-if="!isLoading" fluid  grid-list-md>
     <IFXPageHeader>
@@ -70,6 +75,7 @@ export default {
     <div :style='contactContentStyle'>
       <IFXContactCard v-if='!isContactContentLarge' dense :contact='focusedContact'/>
       <IFXItemDataTable
+        class="full-width"
         :items='filteredItems'
         :headers='headers'
         :selected.sync='selected'

--- a/src/components/organization/IFXOrganizationCreateEdit.vue
+++ b/src/components/organization/IFXOrganizationCreateEdit.vue
@@ -67,6 +67,7 @@ export default {
             <v-text-field
               v-model='item.name'
               label='Name'
+              data-cy='name'
               :rules='formRules.generic'
               :error-messages='errors.name'
               required
@@ -76,6 +77,7 @@ export default {
             <v-select
               v-model='item.rank'
               label='Rank'
+              data-cy='rank'
               :rules='formRules.generic'
               :error-messages='errors.rank'
               :items="apiRef.validRanks"
@@ -88,6 +90,7 @@ export default {
             <v-text-field
               v-model='item.orgTree'
               label='Org tree'
+              data-cy='org-tree'
               :rules='orgTreeRules'
               :error-messages='errors.org_tree'
               required

--- a/src/components/organization/IFXOrganizationDetail.vue
+++ b/src/components/organization/IFXOrganizationDetail.vue
@@ -1,6 +1,7 @@
 <script>
 import IFXItemSelectList from '@/components/item/IFXItemSelectList'
 import IFXItemDetailMixin from '@/components/item/IFXItemDetailMixin'
+import IFXDeleteItemButton from '@/components/item/IFXDeleteItemButton'
 import IFXOrganizationMixin from '@/components/organization/IFXOrganizationMixin'
 import IFXSelectableContact from '@/components/contact/IFXSelectableContact'
 import IFXSelectableUser from '@/components/user/IFXSelectableUser'
@@ -11,7 +12,8 @@ export default {
   components: {
     IFXItemSelectList,
     IFXSelectableContact,
-    IFXSelectableUser
+    IFXSelectableUser,
+    IFXDeleteItemButton
   },
   methods: {
     displayRank() {
@@ -43,9 +45,11 @@ export default {
   <v-container v-if="!isLoading">
     <IFXPageHeader>
       <template #title>{{ item.slug }}</template>
+      <template #cypress>{{ item.id }}</template>
       <template #actions>
         <!-- TODO: check why this cannot be edited -->
         <IFXButton v-if="!item.ifxOrg" btnType="edit" @action="navigateToItemEdit(id)"/>
+        <IFXDeleteItemButton v-if="!item.ifxOrg" :item='item' :apiRef='apiRef' :itemType='itemType'/>
       </template>
     </IFXPageHeader>
     <v-container px-5 py-0>

--- a/src/components/page/IFXPageHeader.vue
+++ b/src/components/page/IFXPageHeader.vue
@@ -56,6 +56,7 @@ export default {
         <div class='title-ctr'>
           <h1 data-cy='header-title' :class="headerClass"><slot name="title"></slot></h1>
           <h1 data-cy='header-id' :class='headerClass'><slot name='id'></slot></h1>
+          <span data-cy='header-id' class='d-none'><slot name='cypress'></slot></span>
         </div>
         <div class="actions-ctr" :class="actionsContainerClass">
           <slot name="actions">


### PR DESCRIPTION
This PR fixes issues and adds features that are required to make some of the Cypress tests pass. This includes having contacts work and adding a `cypress` slot to the header in `IFXPageHeader` to put the record's ID in.

I've also relaid out the contacts page slightly to allow the next/prev arrows in the footer pager not to wrap.
