### PR TITLE
Add billing records components

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,3 +15,5 @@ build-no-cache:
 	yarn build
 build:
 	yarn build
+serve:
+	yarn serve

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Example (in App.js or any other top-level component):
 <IFXDisplayMessage :top=true :color="success" :timeout=5000/>
 ```
 ## Local app development
- `IFXVue` to be used as a standalone app for development/testing purposes. To use this, you should copy `src/AppTemplate.vue` to `src/App.vue` and issue the `npm run serve` command in a terminal. This will start a development server that will do hot reloading. `src/App.vue` should be `.gitignore`d so you shouldn't been to revert changes before checking things in but it can't hurt.
+ `IFXVue` to be used as a standalone app for development/testing purposes. To use this, you should copy `src/AppTemplate.vue` to `src/App.vue` and issue the `make serve` or `npm run serve` command in a terminal. This will start a development server that will do hot reloading. `src/App.vue` should be `.gitignore`d so you shouldn't been to revert changes before checking things in but it can't hurt.
 
  If you navigate to [localhost](http://localhost:8080/) (or whereever the development server tells you to go), you should see the instructions card. Start editting `src/App.vue` with the code you want to develop/test. For example, develop a new component and "instantiate" it in `src/App.vue`.
 

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "vuetify-loader": "1.6.0",
     "@mdi/font": "5.8.55",
     "material-design-icons-iconfont": "6.1.0",
+    "axios-mock-adapter": "1.20.0",
     "webpack": "^4.44.2"
   },
   "postcss": {

--- a/src/AppTemplate.vue
+++ b/src/AppTemplate.vue
@@ -37,8 +37,10 @@ export default {
                 </li>
                 <li>
                   From a terminal, use the
+                  <code>make serve</code>
+                  or
                   <code>npm run serve</code>
-                  command to start a development server
+                  commands to start a development server
                 </li>
                 <li>???</li>
                 <li>Profit!</li>

--- a/src/components/billingRecord/IFXBillingRecord.js
+++ b/src/components/billingRecord/IFXBillingRecord.js
@@ -22,14 +22,6 @@ export class BillingTransaction extends IFXItemBase {
     this.data.rate = rate
   }
 
-  get dollarValue() {
-    return (this.data.charge / 100).toFixed(2)
-  }
-
-  set dollarValue(charge) {
-    this.data.charge = Math.round(charge * 100)
-  }
-
   get description() {
     return this.data.description
   }

--- a/src/components/billingRecord/IFXBillingRecord.js
+++ b/src/components/billingRecord/IFXBillingRecord.js
@@ -1,0 +1,162 @@
+import IFXItemBase from '@/components/item/IFXItemBase'
+
+export class BillingTransaction extends IFXItemBase {
+  constructor(data = {}) {
+    super(data)
+    // Set default template values here
+  }
+
+  get charge() {
+    return this.data.charge
+  }
+
+  set charge(charge) {
+    this.data.charge = charge
+  }
+
+  get rate() {
+    return this.data.rate
+  }
+
+  set rate(rate) {
+    this.data.rate = rate
+  }
+
+  get description() {
+    return this.data.description
+  }
+
+  set description(description) {
+    this.data.description = description
+  }
+
+  get author() {
+    return this.data.author
+  }
+
+  set author(author) {
+    this.data.author = author
+  }
+
+  get created() {
+    return this.data.created
+  }
+
+  set created(created) {
+    this.data.created = created
+  }
+}
+
+export default class BillingRecord extends IFXItemBase {
+  constructor(data = {}) {
+    super(data)
+  }
+
+  get account() {
+    return this.data.account
+  }
+
+  set account(account) {
+    this.data.account = account
+  }
+
+  get productUsage() {
+    return this.data.product_usage
+  }
+
+  set productUsage(product_usage) {
+    this.data.product_usage = product_usage
+  }
+
+  get productUser() {
+    return this.data.product_usage.product_user
+  }
+
+  get product() {
+    return this.data.product_usage.product
+  }
+
+  get charge() {
+    return this.data.charge
+  }
+
+  set charge(charge) {
+    this.data.charge = charge
+  }
+
+  get description() {
+    return this.data.description
+  }
+
+  set description(description) {
+    this.data.description = description
+  }
+
+  get year() {
+    return this.data.year
+  }
+
+  set year(year) {
+    this.data.year = year
+  }
+
+  get month() {
+    return this.data.month
+  }
+
+  set month(month) {
+    this.data.month = month
+  }
+
+  get currentState() {
+    return this.data.current_state
+  }
+
+  set currentState(current_state) {
+    this.data.current_state = current_state
+  }
+
+  get billingRecordStates() {
+    return this.data.billing_record_states
+  }
+
+  set billingRecordStates(billing_record_states) {
+    this.data.billing_record_states = billing_record_states
+  }
+
+  get transactions() {
+    return this.data.transactions
+  }
+
+  set transactions(transactions) {
+    this.data.transactions = Array.from(transactions)
+  }
+
+  addTransaction(transaction) {
+    this.data.transactions.push(transaction)
+  }
+
+  get percent() {
+    return this.data.percent
+  }
+
+  set rate(rate) {
+    this.data.rate = rate
+  }
+
+  set precent(precent) {
+    this.data.precent = precent
+  }
+
+  get rate() {
+    return this.data.rate
+  }
+
+  get created() {
+    return this.data.created
+  }
+
+  get updated() {
+    return this.data.updated
+  }
+}

--- a/src/components/billingRecord/IFXBillingRecord.js
+++ b/src/components/billingRecord/IFXBillingRecord.js
@@ -22,6 +22,14 @@ export class BillingTransaction extends IFXItemBase {
     this.data.rate = rate
   }
 
+  get dollarValue() {
+    return (this.data.charge / 100).toFixed(2)
+  }
+
+  set dollarValue(charge) {
+    this.data.charge = Math.round(charge * 100)
+  }
+
   get description() {
     return this.data.description
   }
@@ -132,16 +140,8 @@ export default class BillingRecord extends IFXItemBase {
     this.data.transactions = Array.from(transactions)
   }
 
-  addTransaction(transaction) {
-    this.data.transactions.push(transaction)
-  }
-
   get percent() {
     return this.data.percent
-  }
-
-  set rate(rate) {
-    this.data.rate = rate
   }
 
   set precent(precent) {
@@ -152,11 +152,19 @@ export default class BillingRecord extends IFXItemBase {
     return this.data.rate
   }
 
+  set rate(rate) {
+    this.data.rate = rate
+  }
+
   get created() {
     return this.data.created
   }
 
   get updated() {
     return this.data.updated
+  }
+
+  addTransaction(transaction) {
+    this.data.transactions.push(transaction)
   }
 }

--- a/src/components/billingRecord/IFXBillingRecordList.vue
+++ b/src/components/billingRecord/IFXBillingRecordList.vue
@@ -430,18 +430,9 @@ export default {
           .then((response) => {
             this.updating = false
             this.showMessage(response.data.msg)
-            this.items = []
-            this.isLoading = true
-            this.facilityBillingRecords()
-              .then((resp) => (this.message = resp.msg))
-              .catch((error) => {
-                const errorMessage = this.getErrorMessage(error)
-                this.message = `Error loading ${this.facility.name} billing records: ${errorMessage}`
-              })
-              .finally(() => {
-                this.dialog = false
-                this.isLoading = false
-              })
+            const newBillingRec = response.data.data[0]
+            this.items.splice(index, 1, newBillingRec)
+            this.dialog = false
           })
           .catch((error) => {
             this.isLoading = false

--- a/src/components/billingRecord/IFXBillingRecordList.vue
+++ b/src/components/billingRecord/IFXBillingRecordList.vue
@@ -656,7 +656,13 @@ export default {
               {{ item.charge | centsToDollars }}
             </template>
             <template v-slot:item.actions="{ item }">
-              <IFXButton v-if="$api.auth.can('add-transactions')" iconString="add" btnType="add" xSmall @action="openTxnDialog(item)" />
+              <IFXButton
+                v-if="$api.auth.can('add-transactions', $api.authUser)"
+                iconString="add"
+                btnType="add"
+                xSmall
+                @action="openTxnDialog(item)"
+              />
             </template>
             <template v-slot:expanded-item="{ item }">
               <IFXBillingRecordTransactions :billingRecord="item" />

--- a/src/components/billingRecord/IFXBillingRecordList.vue
+++ b/src/components/billingRecord/IFXBillingRecordList.vue
@@ -1,0 +1,417 @@
+<script>
+import IFXBillingRecordMixin from '@/components/billingRecord/IFXBillingRecordMixin'
+import IFXButton from '@/components/IFXButton'
+import IFXBillingRecordTransactions from './IFXBillingRecordTransactions'
+// import IFXItemDataTable from '@/components/item/IFXItemDataTable'
+// import IFXItemListMixin from '@/components/item/IFXItemListMixin'
+
+export default {
+  name: 'IFXBillingRecordList',
+  components: {
+    // IFXItemDataTable,
+    IFXButton,
+    IFXBillingRecordTransactions,
+  },
+  mixins: [IFXBillingRecordMixin],
+  filters: {
+    transactionDisplay(txn) {
+      return `${txn.description}`
+    },
+  },
+  props: {
+    facility: {
+      type: Object,
+      required: true,
+    },
+    date: {
+      type: String,
+      required: true,
+    },
+    organization: {
+      type: Object,
+      required: false,
+      default: null,
+    },
+    app: {
+      type: String,
+      required: true,
+    },
+  },
+  async mounted() {
+    this.isLoading = true
+    await this.facilityBillingRecords()
+    this.isLoading = false
+  },
+  data() {
+    return {
+      isLoading: true,
+      selected: [],
+      items: [],
+      itemKey: 'id',
+      message: '',
+      messageType: 'info',
+      updating: false,
+      allHeaders: [
+        { text: 'ID', value: 'id', sortable: true, hide: true },
+        { text: '', value: 'data-table-expand', sortable: false },
+        { text: 'State', value: 'currentState', sortable: true, width: '100px', namedSlot: true },
+        { text: 'User', value: 'productUser.full_name', sortable: true },
+        { text: 'Lab', value: 'account.organization', sortable: true },
+        { text: 'Expense Code / PO', value: 'account.slug', sortable: true },
+        { text: 'Product', value: 'product', sortable: true },
+        { text: 'Charge', value: 'charge', sortable: true, width: '100px' },
+        { text: 'Percent', value: 'percent', sortable: true, width: '100px' },
+        { text: 'Usage id', value: 'productUsage.id', sortable: true },
+        { text: 'Txn desc', value: 'transactions', sortable: false },
+        { text: 'Actions', value: 'actions', sortable: false },
+      ],
+      isDownloadDisabled: false,
+      rowSelectionToggle: [],
+      rowSelectionToggleIndeterminate: {},
+      tableCollpased: false,
+      search: null,
+      errors: [],
+      isValid: false,
+      dialog: false,
+      editedIndex: -1,
+      editedItem: {
+        rate: 0,
+        charge: null,
+        description: null,
+        author: {},
+        orgRec: {},
+      },
+      defaultItem: {
+        rate: 0,
+        charge: 0,
+        description: '',
+        author: {},
+      },
+    }
+  },
+  computed: {
+    headers() {
+      return this.allHeaders.filter((h) => !h.hide).filter((h) => !this.$vuetify.breakpoint[h.hide])
+    },
+    dateParts: function () {
+      return this.date.split('-')
+    },
+    month: function () {
+      return Number(this.dateParts[1])
+    },
+    year: function () {
+      return Number(this.dateParts[0])
+    },
+    filteredItems: function () {
+      return this.getItemsFilteredBySearch()
+    },
+  },
+  methods: {
+    getErrorMessage(error) {
+      // Regular showMessage is not getting the response data properly
+      let message = 'Unknown error'
+      if (error) {
+        if (
+          error.hasOwnProperty('response')
+          && error.response
+          && error.response.hasOwnProperty('data')
+          && error.response.data
+        ) {
+          message = Object.values(error.response.data).join('\n')
+        } else {
+          message = error
+        }
+      }
+      return message
+    },
+    getItemsFilteredBySearch() {
+      let items = this.items
+      if (this.search) {
+        const search = this.search.toString().toLowerCase()
+        items = items.filter((i) => {
+          let item = i
+          if (i.data) {
+            item = i.data
+          }
+          return Object.keys(item).some((j) => this.filterSearch(item[j], search))
+        })
+      }
+      return items
+    },
+    facilityBillingRecords() {
+      this.clearTableState()
+      return this.$api.billing
+        .getBillingRecords(this.facility.invoicePrefix, this.month, this.year, this.organization)
+        .then((res) => (this.items = res))
+    },
+    toggleGroup(group) {
+      const records = this.filteredItems.filter((item) => item.account.organization === group)
+      const isSelected = this.rowSelectionToggle.indexOf(group) !== -1
+      records.forEach((record) => {
+        const index = this.selected.findIndex((item) => record.id === item.id)
+        if (index !== -1) {
+          if (!isSelected) {
+            this.selected.splice(index, 1)
+          }
+        } else if (isSelected) {
+          this.selected.push(record)
+        }
+      })
+      this.$set(this.rowSelectionToggleIndeterminate, group, false)
+    },
+    summaryCharges(group) {
+      const records = this.filteredItems.filter((item) => item.account.organization === group)
+      const summary = records.reduce((prev, current) => prev + current.charge, 0)
+      return summary
+    },
+    determineGroupState(e) {
+      const group = e.item.account.organization
+      this.$nextTick(() => {
+        const records = this.filteredItems.filter((item) => item.account.organization === group)
+        const checked = this.selected.filter((item) => item.account.organization === group)
+        const state = checked.length !== 0 && checked.length < records.length
+        this.$set(this.rowSelectionToggleIndeterminate, group, state)
+        // Now set the checkbox model to the correct state
+        if (checked.length) {
+          if (checked.length === records.length) {
+            // All are checked so add this if it isn't already there
+            const index = this.rowSelectionToggle.indexOf(group)
+            if (index === -1) {
+              this.rowSelectionToggle.push(group)
+            }
+          }
+        } else {
+          // None are checked so remove this group
+          const index = this.rowSelectionToggle.indexOf(group)
+          if (index !== -1) {
+            this.rowSelectionToggle.splice(index, 1)
+          }
+        }
+      })
+    },
+    toggleSelectAll({ items, value }) {
+      const orgSet = new Set()
+      items.forEach((item) => {
+        orgSet.add(item.account.organization)
+      })
+      this.$nextTick(() => {
+        if (value) {
+          // The user selected all records. Set all the checkboxes on
+          this.rowSelectionToggle = Array.from(orgSet)
+        } else {
+          // They've cleared all records. Remove all orgs from the array
+          this.rowSelectionToggle = []
+        }
+        // And clear indeterminate state
+        this.$set(this.rowSelectionToggleIndeterminate, Array.from(orgSet), false)
+      })
+    },
+    collpaseRows() {
+      // This is a bit of a hack to collpase the group sections when the table loads
+      this.$nextTick(() => {
+        const table = this.$refs.table
+        if (table) {
+          const keys = Object.keys(table.$vnode.componentInstance.openCache)
+          keys.forEach((key) => {
+            table.$vnode.componentInstance.openCache[key] = false
+          })
+        }
+      })
+    },
+    clearTableState() {
+      this.selected = []
+      this.rowSelectionToggle = []
+      this.rowSelectionToggleIndeterminate = {}
+    },
+    closeTxnDialog() {
+      this.dialog = false
+    },
+    openTxnDialog(item) {
+      this.editedItem = { ...this.defaultItem }
+      this.editedItem.rate = item.rate
+      this.editedItem.orgRec = item
+      this.editedItem.author = { ...this.$api.authUser }
+      this.$nextTick(() => {
+        this.dialog = true
+      })
+    },
+    async addNewTransaction(item) {
+      const index = this.items.findIndex((rec) => rec.id === item.orgRec.id)
+      if (index !== -1) {
+        const orgBillingRec = this.items[index]
+        const { charge, rate, description, author } = item
+        const newTransactionData = {
+          charge,
+          rate,
+          description,
+          author,
+        }
+        const newTransaction = this.$api.billingTransaction.create(newTransactionData)
+        orgBillingRec.addTransaction(newTransaction)
+        const newBillingRec = await this.$api.billing.update(this.app, orgBillingRec)
+        this.items.splice(index, 1, newBillingRec[0])
+      }
+      this.dialog = false
+    },
+  },
+  watch: {
+    filteredItems() {
+      if (!this.tableCollpased) {
+        this.collpaseRows()
+        this.tableCollpased = true
+      }
+    },
+  },
+}
+</script>
+<template>
+  <!-- eslint-disable vue/valid-v-slot -->
+  <v-container>
+    <v-row>
+      <v-col id="data-table">
+        <v-data-table
+          ref="table"
+          v-if="filteredItems"
+          v-model="selected"
+          :items="filteredItems"
+          :headers="headers"
+          show-select
+          show-expand
+          expand-icon="mdi-menu-right"
+          :itemKey="itemKey"
+          :loading="isLoading"
+          :items-per-page="-1"
+          group-by="account.organization"
+          @item-selected="determineGroupState"
+          @toggle-select-all="toggleSelectAll"
+        >
+          <template v-slot:group.header="{ group, headers, isOpen, toggle }">
+            <td :colspan="headers.length">
+              <v-row>
+                <v-checkbox
+                  v-model="rowSelectionToggle"
+                  :value="group"
+                  hide-details
+                  multiple
+                  :indeterminate.sync="rowSelectionToggleIndeterminate[group]"
+                  class="shrink ml-3 mt-0"
+                  @click="toggleGroup(group)"
+                ></v-checkbox>
+                <div>
+                  <v-btn icon small @click="toggle">
+                    <v-icon>{{ isOpen ? 'mdi-menu-down' : 'mdi-menu-right' }}</v-icon>
+                  </v-btn>
+                  <span class="group-header">
+                    {{ $api.organization.parseSlug(group).name }}
+                  </span>
+                  <span class="ml-3 font-weight-medium">
+                    Total charges: {{ summaryCharges(group) | centsToDollars }}
+                  </span>
+                </div>
+              </v-row>
+              <v-row></v-row>
+            </td>
+          </template>
+          <template v-slot:item.account.organization="{ item }">
+            <span style="white-space: nowrap">
+              {{ $api.organization.parseSlug(item.account.organization).name }}
+            </span>
+          </template>
+          <template v-slot:item.currentState="{ item }">
+            <span class="state-display">{{ item.currentState | stateDisplay }}</span>
+          </template>
+          <template v-slot:item.account.slug="{ item }">
+            <span style="white-space: nowrap">{{ item.account.code }}</span>
+            ({{ item.account.name }})
+          </template>
+          <template v-slot:item.transactions="{ item }">
+            <div style="min-width: 150px">
+              <v-row v-for="txn in item.transactions" :key="txn.id">
+                {{ txn | transactionDisplay }}
+              </v-row>
+            </div>
+          </template>
+          <template v-slot:item.charge="{ item }">
+            {{ item.charge | centsToDollars }}
+          </template>
+          <template v-slot:item.actions="{ item }">
+            <IFXButton iconString="add" btnType="add" xSmall @action="openTxnDialog(item)" />
+          </template>
+          <template v-slot:expanded-item="{ item }">
+            <IFXBillingRecordTransactions :billingRecord="item" />
+          </template>
+        </v-data-table>
+        <v-dialog v-model="dialog" max-width="600px">
+          <v-card>
+            <v-card-title>
+              <span class="text-h5">Add a new transaction to Billing Record {{ editedItem.orgRec.id }}</span>
+            </v-card-title>
+            <v-card-subtitle>
+              <div class=" py-2 text-h6 font-weight-medium ">Rate is {{ editedItem.rate }}</div>
+            </v-card-subtitle>
+
+            <v-card-text>
+              <v-container>
+                <v-form v-model="isValid" lazy-validation>
+                  <v-row>
+                    <v-col>
+                      <v-text-field
+                        required
+                        v-model="editedItem.charge"
+                        label="Charge"
+                        :error-messages="errors[editedItem.charge]"
+                        :rules="formRules.currency"
+                        prefix="$"
+                      ></v-text-field>
+                    </v-col>
+                  </v-row>
+                  <v-row>
+                    <v-col cols="12">
+                      <v-textarea
+                        required
+                        v-model="editedItem.description"
+                        label="Transaction description"
+                        :error-messages="errors[editedItem.description]"
+                        :rules="formRules.generic"
+                      ></v-textarea>
+                    </v-col>
+                  </v-row>
+                </v-form>
+              </v-container>
+            </v-card-text>
+
+            <v-card-actions>
+              <v-spacer></v-spacer>
+              <v-btn color="blue darken-1" text @click="closeTxnDialog">
+                Cancel
+              </v-btn>
+              <v-btn color="blue darken-1" text :disabled="!isValid" @click="addNewTransaction(editedItem)">
+                Save
+              </v-btn>
+            </v-card-actions>
+          </v-card>
+        </v-dialog>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+<style scoped>
+.message-text {
+  font-size: smaller;
+  font-style: italic;
+  color: red;
+}
+.state-display {
+  font-size: smaller;
+}
+</style>
+<style>
+#data-table .v-data-table__expand-icon--active {
+  -webkit-transform: rotate(90deg);
+  transform: rotate(90deg);
+}
+#data-table .v-data-table > .v-data-table__wrapper tbody tr.v-data-table__expanded__content {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+}
+</style>

--- a/src/components/billingRecord/IFXBillingRecordList.vue
+++ b/src/components/billingRecord/IFXBillingRecordList.vue
@@ -656,7 +656,7 @@ export default {
               {{ item.charge | centsToDollars }}
             </template>
             <template v-slot:item.actions="{ item }">
-              <IFXButton iconString="add" btnType="add" xSmall @action="openTxnDialog(item)" />
+              <IFXButton v-if="$api.auth.can('add-transactions')" iconString="add" btnType="add" xSmall @action="openTxnDialog(item)" />
             </template>
             <template v-slot:expanded-item="{ item }">
               <IFXBillingRecordTransactions :billingRecord="item" />

--- a/src/components/billingRecord/IFXBillingRecordList.vue
+++ b/src/components/billingRecord/IFXBillingRecordList.vue
@@ -189,6 +189,22 @@ export default {
       }
       return items
     },
+    // TODO: this is inefficient because it's checking all attributes
+    // Make it check only relevant fields
+    // Taken almost directly from the Vuetify docs
+    filterSearch(v, s) {
+      let search = s
+      if (search && v) {
+        const val = v.toString().toLowerCase()
+        // If search is number, remove any decimal places, as values are stored as integers
+        if (Number.parseFloat(search)) {
+          search = search.replace('.', '')
+        }
+        return val !== null && ['undefined', 'boolean'].indexOf(typeof val) === -1 && val.indexOf(search) !== -1
+      }
+      return false
+    },
+
     getLabelsForExport() {
       return this.allHeaders.map((h) => h.text)
     },

--- a/src/components/billingRecord/IFXBillingRecordMixin.js
+++ b/src/components/billingRecord/IFXBillingRecordMixin.js
@@ -1,0 +1,8 @@
+export default {
+  data() {
+    return {
+      itemType: 'BillingRecord',
+      apiRef: this.$api.billing,
+    }
+  },
+}

--- a/src/components/billingRecord/IFXBillingRecordMixin.js
+++ b/src/components/billingRecord/IFXBillingRecordMixin.js
@@ -2,7 +2,7 @@ export default {
   data() {
     return {
       itemType: 'BillingRecord',
-      apiRef: this.$api.billing,
+      apiRef: this.$api.billingRecord,
     }
   },
 }

--- a/src/components/billingRecord/IFXBillingRecordTransactions.vue
+++ b/src/components/billingRecord/IFXBillingRecordTransactions.vue
@@ -1,0 +1,54 @@
+<script>
+export default {
+  name: 'IFXBillingRecordTransactions',
+  components: {},
+  props: {
+    billingRecord: {
+      type: Object,
+      required: true,
+    },
+  },
+  mounted() {},
+  data() {
+    return {
+      txnHeaders: [
+        { text: 'ID', value: 'id', sortable: true, hide: true },
+        { text: 'Charge', value: 'charge', sortable: true, width: '100px', namedSlot: true },
+        { text: 'Rate', value: 'rate', sortable: true },
+        { text: 'User', value: 'author.full_name', sortable: true },
+        { text: 'Description', value: 'description', sortable: true },
+      ],
+    }
+  },
+  computed: {},
+  methods: {},
+  watch: {},
+}
+</script>
+<template>
+  <!-- eslint-disable vue/valid-v-slot -->
+  <td :colspan="12" class="pl-10 pr-0 pb-1">
+    <v-data-table
+      :headers="txnHeaders"
+      :items="billingRecord.transactions"
+      class="elevation-1"
+      hide-default-footer
+      dense
+    >
+      <template v-slot:item.charge="{ item }">
+        {{ item.charge | centsToDollars }}
+      </template>
+    </v-data-table>
+  </td>
+</template>
+<style scoped></style>
+<style>
+#data-table .v-data-table__expand-icon--active {
+  -webkit-transform: rotate(90deg);
+  transform: rotate(90deg);
+}
+#data-table .v-data-table > .v-data-table__wrapper tbody tr.v-data-table__expanded__content {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+}
+</style>

--- a/src/components/product/IFXProduct.js
+++ b/src/components/product/IFXProduct.js
@@ -33,14 +33,6 @@ export class ProductRate extends IFXItemBase {
     this.data.price = Math.round(price * 100)
   }
 
-  get id() {
-    return this.data.id
-  }
-
-  set id(id) {
-    this.data.id = id
-  }
-
   get units() {
     return this.data.units
   }

--- a/src/components/product/IFXProduct.js
+++ b/src/components/product/IFXProduct.js
@@ -64,6 +64,10 @@ export class ProductRate extends IFXItemBase {
   set active(active) {
     this.data.is_active = active
   }
+
+  get description() {
+    return `${this.price} per ${this.units}`
+  }
 }
 
 export class Product extends IFXItemBase {

--- a/src/entrypoint.js
+++ b/src/entrypoint.js
@@ -93,6 +93,9 @@ import IFXProductDetail from '@/components/product/IFXProductDetail'
 import IFXProductCreateEdit from '@/components/product/IFXProductCreateEdit'
 import IFXProductMixin from '@/components/product/IFXProductMixin'
 
+// Billing
+import IFXBillingRecordList from '@/components/billingRecord/IFXBillingRecordList'
+
 import IFXLoginIcon from '@/components/IFXLoginIcon'
 import IFXEnabledIcon from '@/components/IFXEnabledIcon'
 import IFXDataTableCell from '@/components/IFXDataTableCell'
@@ -167,6 +170,7 @@ export {
   IFXProductMixin,
   IFXProductCreateEdit,
   IFXPageActionBar,
+  IFXBillingRecordList,
 }
 
 // Registered globally

--- a/src/filters/IFXFilters.js
+++ b/src/filters/IFXFilters.js
@@ -19,8 +19,8 @@ export function humanDatetime(value) {
  * @returns {number} value in dollars
  */
 export function centsToDollars(cents) {
-  const dollars = cents / 100;
-  return dollars.toLocaleString('en-US', { style: 'currency', currency: 'USD' });
+  const formatter = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' })
+  return formatter.format(cents / 100)
 }
 
 /**
@@ -33,7 +33,7 @@ export function capitalizeFirstLetter(rawValue) {
   if (rawValue) {
     const value = rawValue.toString()
     if (value) {
-      str = value.charAt(0).toUpperCase() + value.slice(1);
+      str = value.charAt(0).toUpperCase() + value.slice(1)
     }
   }
   return str
@@ -61,7 +61,7 @@ export function stateDisplay(value) {
   if (value) {
     const result = value
       .split('_')
-      .map(e => capitalizeFirstLetter(e))
+      .map((e) => capitalizeFirstLetter(e))
       .join(' ')
       .trim()
     return result
@@ -92,7 +92,7 @@ export function affiliationRoleDisplay(value) {
   const displayValues = {
     pi: 'PI',
     lab_manager: 'Lab Manager',
-    memer: 'Member'
+    memer: 'Member',
   }
   if (value && displayValues[value]) {
     result = displayValues[value]

--- a/src/main.js
+++ b/src/main.js
@@ -14,7 +14,7 @@ import vuetify from './plugins/vuetify-local'
 
 const appName = 'ifxvue'
 const appNameFormatted = 'IFXVue'
-const urls = { BILLING: 'billing/' }
+const urls = [{}]
 
 const vars = {
   appName,

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,10 @@
 import Vue from 'vue'
+/* eslint-disable import/no-extraneous-dependencies */
+import IFXFilters from '@/filters/IFXFilters'
+import IFXMixin from '@/mixins/IFXMixin'
+import VCurrencyField from 'v-currency-field'
+
+import MockAdapter from 'axios-mock-adapter'
 import APIService from './api/IFXAPI'
 import App from './App'
 import vuetify from './plugins/vuetify-local'
@@ -8,7 +14,7 @@ import vuetify from './plugins/vuetify-local'
 
 const appName = 'ifxvue'
 const appNameFormatted = 'IFXVue'
-const urls = []
+const urls = { BILLING: 'billing/' }
 
 const vars = {
   appName,
@@ -22,10 +28,34 @@ const APIStore = {
   vars,
   ui: {},
 }
-
 const api = new APIService(APIStore)
+
+const mock = new MockAdapter(api.axios)
+Vue.prototype.$mock = mock
+
 Vue.prototype.$api = Vue.observable(api)
 api.auth.initAuthUser()
+
+// Add filters
+Object.keys(IFXFilters).forEach((name) => {
+  Vue.filter(name, IFXFilters[name])
+})
+
+// Add top-level mixin
+Vue.mixin(IFXMixin)
+
+// Add currencyField package
+Vue.use(VCurrencyField, {
+  locale: 'usd',
+  decimalLength: 2,
+  autoDecimalMode: true,
+  min: null,
+  max: null,
+  defaultValue: null,
+  valueAsInteger: true,
+  allowNegative: false,
+  prefix: '$',
+})
 
 /* eslint-disable no-new */
 new Vue({


### PR DESCRIPTION
This PR moves the Billing Record component into `IFXVue` from `fiine`. It also enhances the component by allowing the display of the individual transactions within a billing record. In addition, it lets the user add a new transaction.

The `billingRecord` api is also added to `IFXAPI.js` to handle the interactions with the billing system.

In addition, the ability to mock up api calls is added to make local development easier. `axios-mock-adapter` is used for this purpose. There are other changes to allow for local development, including adding filters and required imports.

There will be a related `fiine` MR to remove the billing record components from there.
