### PR TITLE
Notify lab managers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ IMAGE         = ifxvue
 container:
 	docker build -t $(IMAGE) .
 run: container
-	docker run --rm -it -v `pwd`:/app/frontend $(IMAGE)
+	docker run --rm -it -p 8080:8080 -v `pwd`:/app/frontend $(IMAGE)
 build-no-cache:
 	rm -rf node_modules/
 	npm cache clean --force && npm cache verify

--- a/src/api/IFXAPI.js
+++ b/src/api/IFXAPI.js
@@ -749,7 +749,6 @@ export default class IFXAPIService {
   }
 
   notifyLabManagers(organizationSlugs, router) {
-    console.log(organizationSlugs)
     router.push({ name: 'MailingCompose', params: { labManagerOrgSlugs: organizationSlugs } })
   }
 }

--- a/src/api/IFXAPI.js
+++ b/src/api/IFXAPI.js
@@ -744,4 +744,8 @@ export default class IFXAPIService {
     }
     return this.axios.get(url)
   }
+
+  notifyLabManagers(organizations){
+
+  }
 }

--- a/src/api/IFXAPI.js
+++ b/src/api/IFXAPI.js
@@ -528,8 +528,12 @@ export default class IFXAPIService {
         if (params && params.org_slugs) {
           params.org_slugs = params.org_slugs.join(',')
         }
-        const contactables = await this.axios.get(url, { params }).then((response) => response.data)
-          .catch((error) => { throw new Error(error) })
+        const contactables = await this.axios
+          .get(url, { params })
+          .then((response) => response.data)
+          .catch((error) => {
+            throw new Error(error)
+          })
         return contactables
       },
     }
@@ -758,9 +762,25 @@ export default class IFXAPIService {
     let message = ''
     let subject = ''
     if (messages.length) {
-      const months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']
+      const months = [
+        'January',
+        'February',
+        'March',
+        'April',
+        'May',
+        'June',
+        'July',
+        'August',
+        'September',
+        'October',
+        'November',
+        'December',
+      ]
       const link = `https://fiine.rc.fas.harvard.edu/fiine/billing/billing-records/list/?year=${year}&month=${month}&facility=${facility.name}`
-      message = messages[0].message.replaceAll('{link}', link).replaceAll('{month}', months[month]).replaceAll('{year}', year)
+      message = messages[0].message
+        .replaceAll('{link}', link)
+        .replaceAll('{month}', months[month])
+        .replaceAll('{year}', year)
       subject = messages[0].subject
     }
 
@@ -770,7 +790,7 @@ export default class IFXAPIService {
         labManagerOrgSlugs: organizationSlugs,
         message: message,
         subject: subject,
-      }
+      },
     })
   }
 }

--- a/src/api/IFXAPI.js
+++ b/src/api/IFXAPI.js
@@ -749,7 +749,6 @@ export default class IFXAPIService {
   }
 
   getLabManagerNotificationMessageName(facility) {
-    console.log(facility)
     return `${this.vars.appName}_${facility.invoicePrefix}_lab_manager_billing_record_notification`
   }
 

--- a/src/api/IFXAPI.js
+++ b/src/api/IFXAPI.js
@@ -11,7 +11,6 @@ import { Organization, OrganizationContact, OrganizationUser } from '@/component
 import IFXMailing from '@/components/mailing/IFXMailing'
 import IFXMessage from '@/components/message/IFXMessage'
 import IFXAuthUser from '@/components/authUser/IFXAuthUser'
-import IFXContactable from '@/components/contactable/IFXContactable'
 import Account from '@/components/account/IFXAccount'
 import ProductAccount from '@/components/account/IFXProductAccount'
 import Facility from '@/components/facility/IFXFacility'
@@ -524,24 +523,10 @@ export default class IFXAPIService {
 
   get contactables() {
     return {
-      create: (data = null) => {
-        console.error('Still need to implement contactable object')
-        return new IFXContactable(data)
-      },
-      getList: async (search, orgTrees) => {
-        const contacts = await this.contact.getList(search).catch((err) => {
-          throw new Error(err)
-        })
-
-        const users = await this.user.getList(search).catch((err) => {
-          throw new Error(err)
-        })
-
-        const organizations = await this.organization.getList({ search, orgTrees }).catch((err) => {
-          throw new Error(err)
-        })
-
-        const contactables = [contacts, organizations, users].flat()
+      getList: async () => {
+        const url = this.urls.CONTACTABLES
+        const contactables = await this.axios.get(url).then((response) => response.data)
+          .catch((error) => { throw new Error(error) })
         return contactables
       },
     }

--- a/src/api/IFXAPI.js
+++ b/src/api/IFXAPI.js
@@ -748,7 +748,30 @@ export default class IFXAPIService {
     return this.axios.get(url)
   }
 
-  notifyLabManagers(organizationSlugs, router) {
-    router.push({ name: 'MailingCompose', params: { labManagerOrgSlugs: organizationSlugs } })
+  getLabManagerNotificationMessageName(facility) {
+    console.log(facility)
+    return `${this.vars.appName}_${facility.invoicePrefix}_lab_manager_billing_record_notification`
+  }
+
+  async notifyLabManagers(organizationSlugs, facility, year, month, router) {
+    const messageName = this.getLabManagerNotificationMessageName(facility)
+    const messages = await this.message.getList({ name: messageName })
+    let message = ''
+    let subject = ''
+    if (messages.length) {
+      const months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']
+      const link = `https://fiine.rc.fas.harvard.edu/fiine/billing/billing-records/list/?year=${year}&month=${month}&facility=${facility.name}`
+      message = messages[0].message.replaceAll('{link}', link).replaceAll('{month}', months[month]).replaceAll('{year}', year)
+      subject = messages[0].subject
+    }
+
+    router.push({
+      name: 'MailingCompose',
+      params: {
+        labManagerOrgSlugs: organizationSlugs,
+        message: message,
+        subject: subject,
+      }
+    })
   }
 }

--- a/src/api/IFXAPI.js
+++ b/src/api/IFXAPI.js
@@ -523,9 +523,12 @@ export default class IFXAPIService {
 
   get contactables() {
     return {
-      getList: async () => {
+      getList: async (params) => {
         const url = this.urls.CONTACTABLES
-        const contactables = await this.axios.get(url).then((response) => response.data)
+        if (params && params.org_slugs) {
+          params.org_slugs = params.org_slugs.join(',')
+        }
+        const contactables = await this.axios.get(url, { params }).then((response) => response.data)
           .catch((error) => { throw new Error(error) })
         return contactables
       },
@@ -745,7 +748,8 @@ export default class IFXAPIService {
     return this.axios.get(url)
   }
 
-  notifyLabManagers(organizations){
-
+  notifyLabManagers(organizationSlugs, router) {
+    console.log(organizationSlugs)
+    router.push({ name: 'MailingCompose', params: { labManagerOrgSlugs: organizationSlugs } })
   }
 }

--- a/src/components/IFXContactablesCombobox.vue
+++ b/src/components/IFXContactablesCombobox.vue
@@ -27,7 +27,7 @@
       <v-list-item v-text='item.text'></v-list-item>
     </template>
     <template #selection="{item}">
-      <v-chip color="transparent" close>
+      <v-chip color="transparent" close draggable>
         <v-icon :color="item.color" class="mr-2">{{item.icon}}</v-icon>{{item.label}}
       </v-chip>
     </template>

--- a/src/components/IFXContactablesCombobox.vue
+++ b/src/components/IFXContactablesCombobox.vue
@@ -27,10 +27,9 @@
       <v-list-item v-text='item.text'></v-list-item>
     </template>
     <template #selection="{item}">
-      <v-chip v-if='isContactableObj(item)' color="transparent" close>
-        <v-icon :color="item.color" class="mr-2">{{item.icon}}</v-icon>{{item.name}}
+      <v-chip color="transparent" close>
+        <v-icon :color="item.color" class="mr-2">{{item.icon}}</v-icon>{{item.label}}
       </v-chip>
-      <v-chip v-else close>{{item}}</v-chip>
     </template>
   </v-combobox>
   </div>
@@ -92,10 +91,6 @@ export default {
       this.$emit('input', this.selected)
       this.search = null
     },
-    // TODO: make this more specific, this way of checking the shape of a contactable is brittle
-    isContactableObj({ slug, color }) {
-      return !!slug && !!color
-    }
   },
   computed: {
     ref() {

--- a/src/components/IFXContactablesCombobox.vue
+++ b/src/components/IFXContactablesCombobox.vue
@@ -1,13 +1,11 @@
 <template>
 <div class="dropdown">
   <v-combobox
-    v-if='!isLoading'
     :ref='ref'
-    :loading="isSearching"
     v-model="selected"
-    :items="items"
+    :items="contactables"
     :search-input.sync="search"
-    @change="clearSearch"
+    @change="handleChange"
     :label="label | capitalizeFirstLetter"
     chips
     clearable
@@ -29,9 +27,10 @@
       <v-list-item v-text='item.text'></v-list-item>
     </template>
     <template #selection="{item}">
-      <v-chip v-if='isContactableObj(item)' color="transparent" close @click:close ="removeRecipient(item)">
-        <v-icon :color="item.color" class="mr-2">{{item.icon}}</v-icon>{{item.name}}</v-chip>
-      <v-chip v-else close @click:close ="removeRecipient(item)">{{item}}</v-chip>
+      <v-chip v-if='isContactableObj(item)' color="transparent" close>
+        <v-icon :color="item.color" class="mr-2">{{item.icon}}</v-icon>{{item.name}}
+      </v-chip>
+      <v-chip v-else close>{{item}}</v-chip>
     </template>
   </v-combobox>
   </div>
@@ -40,7 +39,6 @@
 <script>
 // Primarily used in mailingCompose component for searching through multiple types of objects
 // (i.e. contactables: organization, user, contact)
-import debounce from 'lodash/debounce'
 import { mapActions } from 'vuex'
 
 export default {
@@ -65,21 +63,21 @@ export default {
       required: false,
       default: null
     },
-    orgTree: {
+    contactables: {
       type: Array,
-      required: false,
-      default() {
-        return ['Harvard']
-      }
+      required: true,
+    },
+    value: {
+      type: Array,
+      required: true,
     }
   },
   data() {
     return {
-      isLoading: false,
-      isSearching: false,
       search: null,
       items: [],
       errorMessage: '',
+      selected: [],
     }
   },
   methods: {
@@ -90,18 +88,9 @@ export default {
     getItemValue(item) {
       return item
     },
-    // Debounce so the query doesn't fire on every keydown
-    querySelections: debounce(async function (val) {
-      this.isSearching = true
-      this.items = await this.$api.contactables.getList(val, this.orgTree).then(res => res)
-      this.isSearching = false
-    }, 750),
-    clearSearch() {
+    handleChange() {
+      this.$emit('input', this.selected)
       this.search = null
-    },
-    removeRecipient(item) {
-      const payload = { key: this.label, value: item }
-      this.$store.dispatch('mailing/deleteValue', payload)
     },
     // TODO: make this more specific, this way of checking the shape of a contactable is brittle
     isContactableObj({ slug, color }) {
@@ -115,23 +104,8 @@ export default {
     rules() {
       return this.required ? this.formRules.generic : []
     },
-    selected: {
-      get() {
-        return this.$store.getters[`mailing/${this.label}`]
-      },
-      set(valuesArray) {
-        const payload = { key: this.label, value: valuesArray }
-        this.$store.dispatch('mailing/setValue', payload)
-      }
-    }
   },
   watch: {
-    search(n, o) {
-      if (this.isSearchDisabled) return
-      if (n && this.areValuesDifferent(n, o)) {
-        this.querySelections(n)
-      }
-    },
     fieldError: {
       handler(n) {
         if (n) {
@@ -144,7 +118,9 @@ export default {
     this.isLoading = true
   },
   mounted() {
-    this.$nextTick(() => this.isLoading = false)
+    if (this.value) {
+      this.selected = this.value.slice()
+    }
   }
 }
 </script>

--- a/src/components/IFXTextEditor.vue
+++ b/src/components/IFXTextEditor.vue
@@ -18,18 +18,12 @@ export default {
     Editor
   },
   props: {
-    getText: {
-      type: Function,
-      required: true
-    },
-    setText: {
-      type: Function,
-      required: true
-    },
+    value: null,
   },
   data() {
     return {
       isLoading: false,
+      content: null,
     }
   },
   methods: {
@@ -38,15 +32,6 @@ export default {
     }
   },
   computed: {
-    text: {
-      get() {
-        return this.getText()
-      },
-      set(value) {
-        this.setText(value)
-      }
-    },
-
     init() {
       return {
         height: 300,
@@ -65,6 +50,9 @@ export default {
   },
   created() {
     this.isLoading = true
+  },
+  mounted() {
+    this.content = this.value
   }
 }
 </script>

--- a/src/components/billingRecord/IFXBillingRecordList.vue
+++ b/src/components/billingRecord/IFXBillingRecordList.vue
@@ -5,8 +5,6 @@ import IFXBillingRecordMixin from '@/components/billingRecord/IFXBillingRecordMi
 import IFXButton from '@/components/IFXButton'
 import IFXSearchField from '@/components/IFXSearchField'
 import IFXBillingRecordTransactions from './IFXBillingRecordTransactions'
-// import IFXItemDataTable from '@/components/item/IFXItemDataTable'
-// import IFXItemListMixin from '@/components/item/IFXItemListMixin'
 
 export default {
   name: 'IFXBillingRecordList',
@@ -92,7 +90,6 @@ export default {
       search: null,
       isValid: false,
       dialog: false,
-
       editedItem: {
         rate: 0,
         charge: 0,
@@ -514,6 +511,23 @@ export default {
               </v-col>
               <v-col v-else>
                 <v-row dense class="d-flex justify-space-between">
+                  <v-col class="pa-2">
+                        <v-tooltip top>
+                          <template v-slot:activator="{ on, attrs }">
+                            <div v-on="on">
+                              <v-btn
+                                small
+                                fab
+                                color="green"
+                                v-bind="attrs"
+                              >
+                                <v-icon color="white">mdi-email-send-outline</v-icon>
+                              </v-btn>
+                            </div>
+                          </template>
+                          <span>Notify lab managers</span>
+                        </v-tooltip>
+                  </v-col>
                   <v-col class="pa-2" v-if="allowApprovals">
                     <v-row dense class="d-flex flex-nowrap">
                       <v-col>

--- a/src/components/billingRecord/IFXBillingRecordList.vue
+++ b/src/components/billingRecord/IFXBillingRecordList.vue
@@ -204,7 +204,6 @@ export default {
       }
       return false
     },
-
     getLabelsForExport() {
       return this.allHeaders.map((h) => h.text)
     },
@@ -475,6 +474,10 @@ export default {
     allowAddingTransactions(item) {
       return this.$api.auth.can('add-transactions', this.$api.authUser) && item.currentState !== 'FINAL'
     },
+    notifyLabManagers() {
+      const orgSlugs = this.items.map((item) => item.account.organization)
+      this.$api.notifyLabManagers([...new Set(orgSlugs)], this.$router)
+    }
   },
   watch: {
     filteredItems() {
@@ -520,6 +523,7 @@ export default {
                                 fab
                                 color="green"
                                 v-bind="attrs"
+                                @click="notifyLabManagers"
                               >
                                 <v-icon color="white">mdi-email-send-outline</v-icon>
                               </v-btn>

--- a/src/components/billingRecord/IFXBillingRecordList.vue
+++ b/src/components/billingRecord/IFXBillingRecordList.vue
@@ -476,7 +476,7 @@ export default {
     },
     notifyLabManagers() {
       const orgSlugs = this.items.map((item) => item.account.organization)
-      this.$api.notifyLabManagers([...new Set(orgSlugs)], this.$router)
+      this.$api.notifyLabManagers([...new Set(orgSlugs)], this.facility, this.year, this.month, this.$router)
     }
   },
   watch: {

--- a/src/components/mailing/IFXMailingCompose.vue
+++ b/src/components/mailing/IFXMailingCompose.vue
@@ -35,6 +35,16 @@ export default {
       required: false,
       default: null,
     },
+    subject: {
+      type: String,
+      required: false,
+      default: null,
+    },
+    message: {
+      type: String,
+      required: false,
+      default: null,
+    },
     messageName: {
       type: String,
       required: false,
@@ -62,8 +72,7 @@ export default {
       toList: [],
       ccList: [],
       bccList: [],
-      subject: null,
-      message: null,
+      localSubject: null,
       mailing: null,
       content: null,
       contactables: [],
@@ -81,7 +90,7 @@ export default {
       // Get mailing from vuex - this is where the mailing is stored throughout the composition process
       const mailing = {
         message: this.content,
-        subject: this.subject,
+        subject: this.localSubject,
         fromstr: this.fromAddr,
         tostr: [...new Set(this.toList.map(toMailStr))].join(',')
       }
@@ -121,6 +130,12 @@ export default {
   },
   mounted() {
     const me = this
+    if (this.message) {
+      this.content = this.message
+    }
+    if (this.subject) {
+      this.localSubject = this.subject
+    }
     this.$api.contactables.getList()
       .then((result) => {
         this.contactables = result
@@ -206,7 +221,7 @@ export default {
     if (this.messageName) {
       this.$api.message.getList({ name: this.messageName })
         .then((result) => {
-          this.message = result[0]
+          this.content = result[0]
         })
     }
   }
@@ -254,7 +269,7 @@ export default {
       />
       <v-text-field
         label="Subject"
-        v-model="subject"
+        v-model="localSubject"
         :rules="formRules.generic"
         :error-messages="fieldErrors.subject"
         required

--- a/src/main.js
+++ b/src/main.js
@@ -14,7 +14,11 @@ import vuetify from './plugins/vuetify-local'
 
 const appName = 'ifxvue'
 const appNameFormatted = 'IFXVue'
-const urls = { BILLING: 'billing/' }
+const urls = {
+  BILLING: 'billing/',
+  CONTACTS: 'contacts/',
+  ORGANIZATIONS: 'organizations/',
+}
 
 const vars = {
   appName,

--- a/src/main.js
+++ b/src/main.js
@@ -15,7 +15,7 @@ import vuetify from './plugins/vuetify-local'
 const appName = 'ifxvue'
 const appNameFormatted = 'IFXVue'
 const urls = {
-  BILLING: 'billing/',
+  BILLING_RECORDS: 'billing/',
   CONTACTS: 'contacts/',
   ORGANIZATIONS: 'organizations/',
 }


### PR DESCRIPTION
Button on IFXBillingRecordsList for opening IFXComposeMailing with the list of Lab Manager contacts for the organizations displayed and the standard lab manager notification message.

IFXComposeMailing has been changed to use props instead of the vuex store based composition.  This means other email actions should be modified to use props.

Instead of fetching contacts, org contacts and users separately and combining, ifxuser is now providing a get_contactables endpoint that combines data in a union, complete with icon name and color.

