### PR TITLE
More mail updates

### DIFF
--- a/src/api/IFXAPI.js
+++ b/src/api/IFXAPI.js
@@ -756,7 +756,7 @@ export default class IFXAPIService {
     return `${this.vars.appName}_${facility.invoicePrefix}_lab_manager_billing_record_notification`
   }
 
-  async notifyLabManagers(organizationSlugs, facility, year, month, router) {
+  async notifyLabManagers(organizationSlugs, facility, year, month, recipientField, router) {
     const messageName = this.getLabManagerNotificationMessageName(facility)
     const messages = await this.message.getList({ name: messageName })
     let message = ''
@@ -790,6 +790,7 @@ export default class IFXAPIService {
         labManagerOrgSlugs: organizationSlugs,
         message: message,
         subject: subject,
+        recipientField: recipientField,
       },
     })
   }

--- a/src/components/IFXContactablesCombobox.vue
+++ b/src/components/IFXContactablesCombobox.vue
@@ -27,7 +27,7 @@
       <v-list-item v-text='item.text'></v-list-item>
     </template>
     <template #selection="{item}">
-      <v-chip color="transparent" close>
+      <v-chip color="transparent" close @click:close="removeFromSelected(item)">
         <v-icon :color="item.color" class="mr-2">{{item.icon}}</v-icon>{{item.label}}
       </v-chip>
     </template>
@@ -86,6 +86,9 @@ export default {
     },
     getItemValue(item) {
       return item
+    },
+    removeFromSelected(item) {
+      this.selected.splice(this.selected.findIndex((i) => i.id === item.id), 1)
     },
     handleChange() {
       this.$emit('input', this.selected)

--- a/src/components/billingRecord/IFXBillingRecordList.vue
+++ b/src/components/billingRecord/IFXBillingRecordList.vue
@@ -103,6 +103,7 @@ export default {
         description: '',
         author: {},
       },
+      mailFab: false,
     }
   },
   computed: {
@@ -474,9 +475,9 @@ export default {
     allowAddingTransactions(item) {
       return this.$api.auth.can('add-transactions', this.$api.authUser) && item.currentState !== 'FINAL'
     },
-    notifyLabManagers() {
+    notifyLabManagers(recipientField) {
       const orgSlugs = this.items.map((item) => item.account.organization)
-      this.$api.notifyLabManagers([...new Set(orgSlugs)], this.facility, this.year, this.month, this.$router)
+      this.$api.notifyLabManagers([...new Set(orgSlugs)], this.facility, this.year, this.month, recipientField, this.$router)
     }
   },
   watch: {
@@ -515,22 +516,63 @@ export default {
               <v-col v-else>
                 <v-row dense class="d-flex justify-space-between">
                   <v-col class="pa-2">
-                        <v-tooltip top>
-                          <template v-slot:activator="{ on, attrs }">
-                            <div v-on="on">
+                    <v-tooltip top>
+                      <template v-slot:activator="{ on, attrs }">
+                        <div v-on="on">
+                          <v-speed-dial
+                            direction="bottom"
+                            v-model="mailFab"
+                            v-bind="attrs"
+                          >
+                            <template v-slot:activator>
                               <v-btn
+                                v-model="mailFab"
                                 small
-                                fab
                                 color="green"
-                                v-bind="attrs"
-                                @click="notifyLabManagers"
+                                fab
                               >
-                                <v-icon color="white">mdi-email-send-outline</v-icon>
+                                <v-icon color="white" v-if="mailFab">
+                                  mdi-close
+                                </v-icon>
+                                <v-icon color="white" v-else>
+                                  mdi-email-send-outline
+                                </v-icon>
                               </v-btn>
-                            </div>
-                          </template>
-                          <span>Notify lab managers</span>
-                        </v-tooltip>
+                            </template>
+                            <v-btn
+                              xSmall
+                              fab
+                              color="#A4F323"
+                              @click="notifyLabManagers('to')"
+                              :disabled="!filteredItems.length"
+                            >
+                              to:
+                            </v-btn>
+                            <v-btn
+                              xSmall
+                              fab
+                              color="#86C61D"
+                              @click="notifyLabManagers('cc')"
+                              :disabled="!filteredItems.length"
+                            >
+                              cc:
+                            </v-btn>
+                            <v-btn
+                              xSmall
+                              fab
+                              color="#669617"
+                              @click="notifyLabManagers('bcc')"
+                              :disabled="!filteredItems.length"
+                            >
+                              bcc:
+                            </v-btn>
+                          </v-speed-dial>
+                        </div>
+                      </template>
+                      <span>
+                        Notify lab managers
+                      </span>
+                    </v-tooltip>
                   </v-col>
                   <v-col class="pa-2" v-if="allowApprovals">
                     <v-row dense class="d-flex flex-nowrap">

--- a/src/components/billingRecord/IFXBillingRecordList.vue
+++ b/src/components/billingRecord/IFXBillingRecordList.vue
@@ -4,6 +4,7 @@ import { mapActions } from 'vuex'
 import IFXBillingRecordMixin from '@/components/billingRecord/IFXBillingRecordMixin'
 import IFXButton from '@/components/IFXButton'
 import IFXSearchField from '@/components/IFXSearchField'
+import IFXMailButton from '@/components/mailing/IFXMailButton'
 import IFXBillingRecordTransactions from './IFXBillingRecordTransactions'
 
 export default {
@@ -13,6 +14,7 @@ export default {
     IFXButton,
     IFXSearchField,
     IFXBillingRecordTransactions,
+    IFXMailButton,
   },
   mixins: [IFXBillingRecordMixin],
   filters: {
@@ -104,6 +106,7 @@ export default {
         author: {},
       },
       mailFab: false,
+      recipientField: '',
     }
   },
   computed: {
@@ -475,9 +478,9 @@ export default {
     allowAddingTransactions(item) {
       return this.$api.auth.can('add-transactions', this.$api.authUser) && item.currentState !== 'FINAL'
     },
-    notifyLabManagers(recipientField) {
+    notifyLabManagers() {
       const orgSlugs = this.items.map((item) => item.account.organization)
-      this.$api.notifyLabManagers([...new Set(orgSlugs)], this.facility, this.year, this.month, recipientField, this.$router)
+      this.$api.notifyLabManagers([...new Set(orgSlugs)], this.facility, this.year, this.month, this.recipientField, this.$router)
     }
   },
   watch: {
@@ -516,63 +519,13 @@ export default {
               <v-col v-else>
                 <v-row dense class="d-flex justify-space-between">
                   <v-col class="pa-2">
-                    <v-tooltip top>
-                      <template v-slot:activator="{ on, attrs }">
-                        <div v-on="on">
-                          <v-speed-dial
-                            direction="bottom"
-                            v-model="mailFab"
-                            v-bind="attrs"
-                          >
-                            <template v-slot:activator>
-                              <v-btn
-                                v-model="mailFab"
-                                small
-                                color="green"
-                                fab
-                              >
-                                <v-icon color="white" v-if="mailFab">
-                                  mdi-close
-                                </v-icon>
-                                <v-icon color="white" v-else>
-                                  mdi-email-send-outline
-                                </v-icon>
-                              </v-btn>
-                            </template>
-                            <v-btn
-                              xSmall
-                              fab
-                              color="#A4F323"
-                              @click="notifyLabManagers('to')"
-                              :disabled="!filteredItems.length"
-                            >
-                              to:
-                            </v-btn>
-                            <v-btn
-                              xSmall
-                              fab
-                              color="#86C61D"
-                              @click="notifyLabManagers('cc')"
-                              :disabled="!filteredItems.length"
-                            >
-                              cc:
-                            </v-btn>
-                            <v-btn
-                              xSmall
-                              fab
-                              color="#669617"
-                              @click="notifyLabManagers('bcc')"
-                              :disabled="!filteredItems.length"
-                            >
-                              bcc:
-                            </v-btn>
-                          </v-speed-dial>
-                        </div>
-                      </template>
-                      <span>
-                        Notify lab managers
-                      </span>
-                    </v-tooltip>
+                    <IFXMailButton
+                      v-model="recipientField"
+                      :disabled="!filteredItems.length"
+                      toolTip="Notify Lab Managers"
+                      @input="notifyLabManagers()"
+                    >
+                    </IFXMailButton>
                   </v-col>
                   <v-col class="pa-2" v-if="allowApprovals">
                     <v-row dense class="d-flex flex-nowrap">

--- a/src/components/contact/IFXContact.js
+++ b/src/components/contact/IFXContact.js
@@ -93,4 +93,14 @@ export default class Contact extends IFXItemBase {
   get created() {
     return this.data.created
   }
+
+  get computedName() {
+    // Used in contact list display
+    return this.org ? `${this.org} (${this.name})` : this.name
+  }
+
+  get key() {
+    // Needed for item list because id is not unique
+    return `${this.id}${this.org}`
+  }
 }

--- a/src/components/contact/IFXContactCard.vue
+++ b/src/components/contact/IFXContactCard.vue
@@ -53,7 +53,7 @@ export default {
       <v-card-title xs-12 v-if="contactData.org"> <!-- So that contacts on the OrganizationDetail page don't see blank space -->
         <v-col alignContent='start' justify="start">
           <v-row>
-            <div class="headline">{{ contactData.org }}</div>
+            <div class="headline">{{ contactData.org }} ({{ contactData.name }})</div>
           </v-row>
         </v-col>
       </v-card-title>

--- a/src/components/contact/IFXContactList.vue
+++ b/src/components/contact/IFXContactList.vue
@@ -2,7 +2,7 @@
 /* eslint-disable no-unused-vars */
 import IFXContactMixin from '@/components/contact/IFXContactMixin'
 import IFXContactCard from '@/components/contact/IFXContactCard'
-import IFXActionSelect from '@/components/action/IFXActionSelect'
+import IFXMailButton from '@/components/mailing/IFXMailButton'
 import IFXSearchField from '@/components/IFXSearchField'
 import IFXItemDataTable from '@/components/item/IFXItemDataTable'
 import IFXItemListMixin from '@/components/item/IFXItemListMixin'
@@ -13,23 +13,28 @@ export default {
   components: {
     IFXContactCard,
     IFXSearchField,
-    IFXActionSelect,
+    IFXMailButton,
     IFXItemDataTable,
   },
   data() {
     return {
-      focusedContact: {}
+      focusedContact: {},
+      recipientField: '',
     }
   },
   methods: {
     setFocusedContact(contact) {
       this.focusedContact = contact
+    },
+    composeEmail() {
+      const recipients = this.selected.map((item) => item.detail).join(',')
+      this.$router.push({ name: 'MailingCompose', params: { recipients: recipients, recipientField: this.recipientField } })
     }
   },
   computed: {
     headers() {
       const headers = [
-        { text: 'Name', value: 'name', sortable: true },
+        { text: 'Name', value: 'computedName', sortable: true },
         { text: 'Detail', value: 'detail', slot: true, sortable: true },
         { text: 'Created', value: 'created', namedSlot: true, sortable: true },
       ]
@@ -63,14 +68,23 @@ export default {
     <IFXPageHeader>
       <template #title>{{listTitle}}</template>
       <template #actions>
-        <IFXSearchField :search.sync='search'/>
-        <IFXActionSelect
-          :actionKeys="['addMailingTo', 'addMailingCC', 'addMailingBCC', 'deleteContacts']"
-          :apiRef='apiRef'
-          @get-set-items='getSetItems'
-          :selectedItems.sync='selected'
-        />
-        <IFXButton btnType="add" xSmall @action="navigateToItemCreate"/>
+        <v-row nowrap align="center">
+          <v-col>
+            <IFXSearchField :search.sync='search'/>
+          </v-col>
+          <v-col>
+            <IFXMailButton
+              v-model="recipientField"
+              toolTip="Email contacts"
+              :disabled="!selected.length"
+              @input="composeEmail()"
+            >
+            </IFXMailButton>
+          </v-col>
+          <v-col>
+            <IFXButton small btnType="add" @action="navigateToItemCreate"/>
+          </v-col>
+        </v-row>
       </template>
     </IFXPageHeader>
     <div :style='contactContentStyle'>
@@ -81,6 +95,7 @@ export default {
         :headers='headers'
         :selected.sync='selected'
         :itemType='itemType'
+        itemKey='key'
         @click-row='setFocusedContact'
       >
         <template v-slot:created="{ item }">

--- a/src/components/mailing/IFXMailButton.vue
+++ b/src/components/mailing/IFXMailButton.vue
@@ -1,0 +1,106 @@
+<script>
+// Speed dial control for sending items to to:, cc:, or bcc: fields on IFXMailingCompose
+// v-model should be bound to the "selected" list.  Check for length of input determines enabled state
+
+export default {
+  name: 'IFXMailButton',
+  props: {
+    value: {
+      type: String,
+      required: true,
+    },
+    disabled: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+    toolTip: {
+      type: String,
+      required: false,
+      default: 'Compose message with selected',
+    },
+    direction: {
+      type: String,
+      required: false,
+      default: 'bottom',
+    },
+    icon: {
+      type: String,
+      required: false,
+      default: 'mdi-email-send-outline'
+    },
+    color: {
+      type: String,
+      required: false,
+      default: 'green',
+    }
+  },
+  data() {
+    return {
+      mailFab: false
+    }
+  },
+  methods: {
+    setRecipientField(field) {
+      this.$emit('input', field)
+    }
+  }
+}
+</script>
+<template>
+  <v-tooltip top>
+    <template v-slot:activator="{ on, attrs }">
+      <div v-on="on">
+        <v-speed-dial
+          :direction="direction"
+          v-model="mailFab"
+          v-bind="attrs"
+        >
+          <template v-slot:activator>
+            <v-btn
+              v-model="mailFab"
+              small
+              :color="color"
+              fab
+              :disabled="disabled"
+            >
+              <v-icon color="white" v-if="mailFab">
+                mdi-close
+              </v-icon>
+              <v-icon color="white" v-else>
+                {{ icon }}
+              </v-icon>
+            </v-btn>
+          </template>
+          <v-btn
+            xSmall
+            fab
+            color="#A4F323"
+            @click="setRecipientField('to')"
+          >
+            to:
+          </v-btn>
+          <v-btn
+            xSmall
+            fab
+            color="#86C61D"
+            @click="setRecipientField('cc')"
+          >
+            cc:
+          </v-btn>
+          <v-btn
+            xSmall
+            fab
+            color="#669617"
+            @click="setRecipientField('bcc')"
+          >
+            bcc:
+          </v-btn>
+        </v-speed-dial>
+      </div>
+    </template>
+    <span>
+      {{ toolTip }}
+    </span>
+  </v-tooltip>
+</template>

--- a/src/components/mailing/IFXMailingCompose.vue
+++ b/src/components/mailing/IFXMailingCompose.vue
@@ -90,6 +90,15 @@ export default {
   },
   methods: {
     ...mapActions(['showMessage']),
+    extractEmailAddress(str) {
+      // If email is of the form Name <email>, extract the email.  Otherwise return
+      let result = str
+      if (str && str.indexOf('<') !== -1) {
+        const match = str.match(/<\s*([^ >]+)\s*>/)
+        if (match) { result = match[1] }
+      }
+      return result
+    },
     sendMailing() {
       const toMailStr = (contactable) => {
         if (contactable.name) {
@@ -195,15 +204,16 @@ export default {
         }
         if (this.to) {
           this.to.split(',').forEach((ele) => {
-            const matches = this.contactables.filter((contactable) => contactable.detail === ele)
+            const email = this.extractEmailAddress(ele)
+            const matches = this.contactables.filter((contactable) => contactable.detail === email)
             if (matches) {
               this.toList = this.toList.concat(matches)
             } else {
               this.toList.push(
                 {
-                  detail: ele,
-                  label: ele,
-                  text: ele
+                  detail: email,
+                  label: email,
+                  text: email
                 }
               )
             }
@@ -211,15 +221,16 @@ export default {
         }
         if (this.cc) {
           this.cc.split(',').forEach((ele) => {
-            const matches = this.contactables.filter((contactable) => contactable.detail === ele)
+            const email = this.extractEmailAddress(ele)
+            const matches = this.contactables.filter((contactable) => contactable.detail === email)
             if (matches) {
               this.ccList = this.ccList.concat(matches)
             } else {
               this.ccList.push(
                 {
-                  detail: ele,
-                  label: ele,
-                  text: ele
+                  detail: email,
+                  label: email,
+                  text: email
                 }
               )
             }
@@ -227,15 +238,16 @@ export default {
         }
         if (this.bcc) {
           this.bcc.split(',').forEach((ele) => {
-            const matches = this.contactables.filter((contactable) => contactable.detail === ele)
+            const email = this.extractEmailAddress(ele)
+            const matches = this.contactables.filter((contactable) => contactable.detail === email)
             if (matches) {
               this.bccList = this.bccList.concat(matches)
             } else {
               this.bccList.push(
                 {
-                  detail: ele,
-                  label: ele,
-                  text: ele
+                  detail: email,
+                  label: email,
+                  text: email
                 }
               )
             }
@@ -243,7 +255,8 @@ export default {
         }
         if (this.recipients) {
           this.recipients.split(',').forEach((ele) => {
-            const matches = this.contactables.filter((contactable) => contactable.detail === ele)
+            const email = this.extractEmailAddress(ele)
+            const matches = this.contactables.filter((contactable) => contactable.detail === email)
             if (matches) {
               if (this.recipientField) {
                 switch (this.recipientField) {

--- a/src/components/mailing/IFXMailingCompose.vue
+++ b/src/components/mailing/IFXMailingCompose.vue
@@ -171,6 +171,7 @@ export default {
                 }
               })
               if (me.recipientField) {
+                const badFieldMessage = `An invalid recipient field was specified: ${me.recipientField}`
                 switch (me.recipientField) {
                   case 'to':
                     me.toList = me.toList.concat(result2)
@@ -182,7 +183,7 @@ export default {
                     me.bccList = me.bccList.concat(result2)
                     break
                   default:
-                    console.log('bad recipient')
+                    me.showMessage(badFieldMessage)
                 }
               } else {
                 me.toList = result2
@@ -259,6 +260,7 @@ export default {
             const matches = this.contactables.filter((contactable) => contactable.detail === email)
             if (matches) {
               if (this.recipientField) {
+                const badFieldMessage = `An invalid recipient field was specified: ${me.recipientField}`
                 switch (this.recipientField) {
                   case 'to':
                     this.toList = this.toList.concat(matches)
@@ -270,7 +272,7 @@ export default {
                     this.bccList = this.bccList.concat(matches)
                     break
                   default:
-                    console.log('bad recipient')
+                    this.showMessage(badFieldMessage)
                 }
               } else {
                 this.toList = this.toList.concat(matches)

--- a/src/components/mailing/IFXMailingCompose.vue
+++ b/src/components/mailing/IFXMailingCompose.vue
@@ -54,7 +54,17 @@ export default {
       type: Array,
       required: false,
       default: null
-    }
+    },
+    recipients: {
+      type: String,
+      required: false,
+      default: null
+    },
+    recipientField: {
+      type: String,
+      required: false,
+      default: null
+    },
   },
   data() {
     return {
@@ -151,7 +161,23 @@ export default {
                   orgContactNotFound.push(name)
                 }
               })
-              me.toList = result2
+              if (me.recipientField) {
+                switch (me.recipientField) {
+                  case 'to':
+                    me.toList = me.toList.concat(result2)
+                    break
+                  case 'cc':
+                    me.ccList = me.ccList.concat(result2)
+                    break
+                  case 'bcc':
+                    me.bccList = me.bccList.concat(result2)
+                    break
+                  default:
+                    console.log('bad recipient')
+                }
+              } else {
+                me.toList = result2
+              }
               this.isLoading = false
               if (orgContactNotFound) {
                 const names = orgContactNotFound.join(', ')
@@ -212,6 +238,30 @@ export default {
                   text: ele
                 }
               )
+            }
+          })
+        }
+        if (this.recipients) {
+          this.recipients.split(',').forEach((ele) => {
+            const matches = this.contactables.filter((contactable) => contactable.detail === ele)
+            if (matches) {
+              if (this.recipientField) {
+                switch (this.recipientField) {
+                  case 'to':
+                    this.toList = this.toList.concat(matches)
+                    break
+                  case 'cc':
+                    this.ccList = this.ccList.concat(matches)
+                    break
+                  case 'bcc':
+                    this.bccList = this.bccList.concat(matches)
+                    break
+                  default:
+                    console.log('bad recipient')
+                }
+              } else {
+                this.toList = this.toList.concat(matches)
+              }
             }
           })
         }

--- a/src/components/mailing/IFXMailingCompose.vue
+++ b/src/components/mailing/IFXMailingCompose.vue
@@ -270,7 +270,9 @@ export default {
     if (this.messageName) {
       this.$api.message.getList({ name: this.messageName })
         .then((result) => {
-          this.content = result[0]
+          if (result.length) {
+            this.content = result[0].message
+          }
         })
     }
   }

--- a/src/components/mailing/IFXMailingList.vue
+++ b/src/components/mailing/IFXMailingList.vue
@@ -1,5 +1,4 @@
 <script>
-import IFXActionSelect from '@/components/action/IFXActionSelect'
 import IFXItemDataTable from '@/components/item/IFXItemDataTable'
 import IFXItemListMixin from '@/components/item/IFXItemListMixin'
 import IFXSearchField from '@/components/IFXSearchField'
@@ -11,7 +10,6 @@ export default {
   components: {
     IFXItemDataTable,
     IFXSearchField,
-    IFXActionSelect
   },
   computed: {
     headers() {
@@ -25,7 +23,7 @@ export default {
         { text: 'BCC', hide: 'mdAndDown', value: 'bccstr', namedSlot: true, width: '300px' },
         { text: 'Message', value: 'message', namedSlot: true },
         { text: 'Status', hide: 'mdAndDown', value: 'status' },
-        { text: '', value: 'rowActionCopy', sortable: false }
+        { text: '', value: 'action', namedSlot: true, sortable: false },
       ]
       return headers.filter((h) => !h.hide || !this.$vuetify.breakpoint[h.hide])
     }
@@ -38,6 +36,22 @@ export default {
         query: { next: this.$route.path },
       })
     },
+    composeEmail(item) {
+      const params = {
+        from: item.from,
+        to: item.tostr,
+        subject: item.subject,
+        message: item.message,
+      }
+      if (item.ccstr) {
+        params.cc = item.ccstr
+      }
+      if (item.bccstr) {
+        params.bcc = item.bccstr
+      }
+      console.log('mailing with params ', params)
+      this.$router.push({ name: 'MailingCompose', params: params })
+    }
   }
 }
 </script>
@@ -48,13 +62,7 @@ export default {
       <template #title>{{listTitle}}</template>
       <template #actions>
         <IFXSearchField :search.sync='search'/>
-        <IFXActionSelect
-          :actionKeys="[]"
-          :apiRef='apiRef'
-          @get-set-items='getSetItems'
-          :selectedItems.sync='selected'
-        />
-        <IFXButton btnType="add" @action="navigateToItemCreate"/>
+        <IFXButton small btnType="add" @action="navigateToItemCreate"/>
       </template>
     </IFXPageHeader>
     <IFXItemDataTable
@@ -116,6 +124,26 @@ export default {
           </span>
         </template>
         <span>{{item.message}}</span>
+      </v-tooltip>
+    </template>
+    <template #action="{ item }">
+      <v-tooltip bottom>
+        <template v-slot:activator="{ on, attrs }">
+          <span
+            v-bind="attrs"
+            v-on="on"
+          >
+          <v-btn
+            xSmall
+            fab
+            color="primary"
+            @click="composeEmail(item)"
+          >
+            <v-icon color="white">mdi-email-send-outline</v-icon>
+          </v-btn>
+          </span>
+        </template>
+        <span>Compose a new email from this one</span>
       </v-tooltip>
     </template>
     </IFXItemDataTable>

--- a/src/components/mailing/IFXMailingList.vue
+++ b/src/components/mailing/IFXMailingList.vue
@@ -49,7 +49,6 @@ export default {
       if (item.bccstr) {
         params.bcc = item.bccstr
       }
-      console.log('mailing with params ', params)
       this.$router.push({ name: 'MailingCompose', params: params })
     }
   }

--- a/src/components/message/IFXMessageList.vue
+++ b/src/components/message/IFXMessageList.vue
@@ -17,6 +17,7 @@ export default {
         { text: 'ID', value: 'id', sortable: true },
         { text: 'Subject', value: 'subject' },
         { text: 'Message', value: 'message' },
+        { text: '', value: 'rowActionEdit', slot: true },
         { text: '', value: 'actions', namedSlot: true, sortable: false },
       ]
       return headers.filter((h) => !h.hide || !this.$vuetify.breakpoint[h.hide])
@@ -24,7 +25,6 @@ export default {
   },
   methods: {
     composeWithMessage(item) {
-      console.log('howdy ', item)
       this.$router.push({ name: 'MailingCompose', params: { messageName: item.name } })
     },
   }
@@ -37,7 +37,7 @@ export default {
       <template #title>{{listTitle}}</template>
       <template #actions>
         <IFXSearchField :search.sync='search'/>
-        <IFXButton btnType="add" @action="navigateToItemCreate"/>
+        <IFXButton small btnType="add" @action="navigateToItemCreate"/>
       </template>
     </IFXPageHeader>
     <IFXItemDataTable

--- a/src/components/message/IFXMessageList.vue
+++ b/src/components/message/IFXMessageList.vue
@@ -51,7 +51,7 @@ export default {
           <template v-slot:activator="{ on, attrs }">
             <v-btn
               fab
-              small
+              xSmall
               color="primary"
               @click="composeWithMessage(item)"
               v-bind="attrs"

--- a/src/components/organization/IFXOrganizationList.vue
+++ b/src/components/organization/IFXOrganizationList.vue
@@ -1,9 +1,9 @@
 <script>
-import IFXActionSelect from '@/components/action/IFXActionSelect'
 import IFXSearchField from '@/components/IFXSearchField'
 import IFXItemDataTable from '@/components/item/IFXItemDataTable'
 import IFXItemListMixin from '@/components/item/IFXItemListMixin'
 import IFXOrganizationMixin from '@/components/organization/IFXOrganizationMixin'
+import IFXMailButton from '@/components/mailing/IFXMailButton'
 
 export default {
   name: 'IFXOrganizationList',
@@ -11,7 +11,12 @@ export default {
   components: {
     IFXSearchField,
     IFXItemDataTable,
-    IFXActionSelect
+    IFXMailButton,
+  },
+  data() {
+    return {
+      recipientField: '',
+    }
   },
   computed: {
     headers() {
@@ -26,6 +31,12 @@ export default {
       return headers.filter((h) => !h.hide || !this.$vuetify.breakpoint[h.hide])
     },
   },
+  methods: {
+    emailLabManagers() {
+      const organizationSlugs = this.selected.map((item) => item.slug)
+      this.$router.push({ name: 'MailingCompose', params: { labManagerOrgSlugs: organizationSlugs, recipientField: this.recipientField } })
+    }
+  }
 }
 </script>
 
@@ -34,15 +45,23 @@ export default {
     <IFXPageHeader>
       <template #title>{{listTitle}}</template>
       <template #actions>
-        <IFXSearchField :search.sync='search'/>
-        <!-- TODO: put condition check for nanites org_tree and then add deleteItems action key-->
-        <IFXActionSelect
-          :actionKeys="['addMailingTo', 'addMailingCC', 'addMailingBCC', 'deleteOrganizations']"
-          :apiRef='apiRef'
-          @get-set-items='getSetItems'
-          :selectedItems.sync='selected'
-        />
-        <IFXButton xSmall btnType="add" @action="navigateToItemCreate"/>
+        <v-row nowrap align="center">
+          <v-col>
+            <IFXSearchField :search.sync='search'/>
+          </v-col>
+          <v-col>
+            <IFXMailButton
+              v-model="recipientField"
+              toolTip="Email Lab Managers"
+              :disabled="!selected.length"
+              @input="emailLabManagers()"
+            >
+            </IFXMailButton>
+          </v-col>
+          <v-col>
+            <IFXButton small btnType="add" @action="navigateToItemCreate"/>
+          </v-col>
+        </v-row>
       </template>
     </IFXPageHeader>
     <IFXItemDataTable

--- a/src/components/user/IFXUserList.vue
+++ b/src/components/user/IFXUserList.vue
@@ -1,6 +1,5 @@
 <script>
 import IFXUserMixin from '@/components/user/IFXUserMixin'
-import IFXActionSelect from '@/components/action/IFXActionSelect'
 import IFXSearchField from '@/components/IFXSearchField'
 import IFXItemDataTable from '@/components/item/IFXItemDataTable'
 import IFXItemListMixin from '@/components/item/IFXItemListMixin'
@@ -11,7 +10,6 @@ export default {
   components: {
     IFXSearchField,
     IFXItemDataTable,
-    IFXActionSelect
   },
   props: {
     headers: {
@@ -23,6 +21,7 @@ export default {
   data() {
     return {
       includeDisabled: this.$api.storage.getItem('UserListIncludeDisabled') || false,
+      mailFab: false,
     }
   },
   methods: {
@@ -33,6 +32,15 @@ export default {
         this.showMessage(error)
       }
     },
+    composeEmail(recipientField) {
+      const params = {
+        recipientField: recipientField,
+        recipients: null
+      }
+      params.recipients = this.selected.map((item) => item.primaryEmail).join(',')
+      console.log('params ', params)
+      this.$router.push({ name: 'MailingCompose', params: params })
+    }
   },
   computed: {
     computedHeaders() {
@@ -65,13 +73,73 @@ export default {
     <IFXPageHeader>
       <template #title>{{listTitle}}</template>
       <template #actions>
-        <IFXSearchField :search.sync='search'/>
-        <v-checkbox class="action-item" label="Include disabled" v-model="includeDisabled"></v-checkbox>
-        <IFXActionSelect
-          class='action-item'
-          :selectedItems.sync='selected'
-          :actionKeys="['activateUserLogin', 'deactivateUserLogin', 'addMailingTo', 'addMailingCC', 'addMailingBCC']"
-        ></IFXActionSelect>
+        <v-row nowrap align="center">
+          <v-col>
+            <IFXSearchField :search.sync='search'/>
+          </v-col>
+          <v-col>
+            <v-checkbox class="action-item" label="Include disabled" v-model="includeDisabled"></v-checkbox>
+          </v-col>
+          <v-col>
+            <v-tooltip top>
+              <template v-slot:activator="{ on, attrs }">
+                <div v-on="on">
+                  <v-speed-dial
+                    direction="bottom"
+                    v-model="mailFab"
+                    v-bind="attrs"
+                  >
+                    <template v-slot:activator>
+                      <v-btn
+                        v-model="mailFab"
+                        small
+                        color="green"
+                        fab
+                      >
+                        <v-icon color="white" v-if="mailFab">
+                          mdi-close
+                        </v-icon>
+                        <v-icon color="white" v-else>
+                          mdi-email-send-outline
+                        </v-icon>
+                      </v-btn>
+                    </template>
+                    <v-btn
+                      xSmall
+                      fab
+                      color="#A4F323"
+                      @click="composeEmail('to')"
+                      :disabled="!selected.length"
+                    >
+                      to:
+                    </v-btn>
+                    <v-btn
+                      xSmall
+                      fab
+                      color="#86C61D"
+                      @click="composeEmail('cc')"
+                      :disabled="!selected.length"
+                    >
+                      cc:
+                    </v-btn>
+                    <v-btn
+                      xSmall
+                      fab
+                      color="#669617"
+                      @click="composeEmail('bcc')"
+                      :disabled="!selected.length"
+                    >
+                      bcc:
+                    </v-btn>
+                  </v-speed-dial>
+                </div>
+              </template>
+              <span>
+                Email selected users
+              </span>
+            </v-tooltip>
+          </v-col>
+        </v-row>
       </template>
     </IFXPageHeader>
     <IFXItemDataTable

--- a/src/components/user/IFXUserList.vue
+++ b/src/components/user/IFXUserList.vue
@@ -71,7 +71,7 @@ export default {
 }
 </script>
 <template>
-  <v-container v-if="!isLoading" grid-list-md>
+  <v-container grid-list-md>
     <IFXPageHeader>
       <template #title>{{listTitle}}</template>
       <template #actions>
@@ -95,10 +95,11 @@ export default {
       </template>
     </IFXPageHeader>
     <IFXItemDataTable
-      :items='filteredItems'
-      :headers='computedHeaders'
-      :selected.sync='selected'
-      :itemType='itemType'
+      :items="filteredItems"
+      :headers="computedHeaders"
+      :selected.sync="selected"
+      :itemType="itemType"
+      :loading="isLoading"
     ></IFXItemDataTable>
   </v-container>
 </template>

--- a/src/components/user/IFXUserList.vue
+++ b/src/components/user/IFXUserList.vue
@@ -3,6 +3,7 @@ import IFXUserMixin from '@/components/user/IFXUserMixin'
 import IFXSearchField from '@/components/IFXSearchField'
 import IFXItemDataTable from '@/components/item/IFXItemDataTable'
 import IFXItemListMixin from '@/components/item/IFXItemListMixin'
+import IFXMailButton from '@/components/mailing/IFXMailButton'
 
 export default {
   name: 'IFXUserList',
@@ -10,6 +11,7 @@ export default {
   components: {
     IFXSearchField,
     IFXItemDataTable,
+    IFXMailButton,
   },
   props: {
     headers: {
@@ -22,6 +24,7 @@ export default {
     return {
       includeDisabled: this.$api.storage.getItem('UserListIncludeDisabled') || false,
       mailFab: false,
+      recipientField: '',
     }
   },
   methods: {
@@ -32,13 +35,12 @@ export default {
         this.showMessage(error)
       }
     },
-    composeEmail(recipientField) {
+    composeEmail() {
       const params = {
-        recipientField: recipientField,
+        recipientField: this.recipientField,
         recipients: null
       }
       params.recipients = this.selected.map((item) => item.primaryEmail).join(',')
-      console.log('params ', params)
       this.$router.push({ name: 'MailingCompose', params: params })
     }
   },
@@ -81,63 +83,13 @@ export default {
             <v-checkbox class="action-item" label="Include disabled" v-model="includeDisabled"></v-checkbox>
           </v-col>
           <v-col>
-            <v-tooltip top>
-              <template v-slot:activator="{ on, attrs }">
-                <div v-on="on">
-                  <v-speed-dial
-                    direction="bottom"
-                    v-model="mailFab"
-                    v-bind="attrs"
-                  >
-                    <template v-slot:activator>
-                      <v-btn
-                        v-model="mailFab"
-                        small
-                        color="green"
-                        fab
-                      >
-                        <v-icon color="white" v-if="mailFab">
-                          mdi-close
-                        </v-icon>
-                        <v-icon color="white" v-else>
-                          mdi-email-send-outline
-                        </v-icon>
-                      </v-btn>
-                    </template>
-                    <v-btn
-                      xSmall
-                      fab
-                      color="#A4F323"
-                      @click="composeEmail('to')"
-                      :disabled="!selected.length"
-                    >
-                      to:
-                    </v-btn>
-                    <v-btn
-                      xSmall
-                      fab
-                      color="#86C61D"
-                      @click="composeEmail('cc')"
-                      :disabled="!selected.length"
-                    >
-                      cc:
-                    </v-btn>
-                    <v-btn
-                      xSmall
-                      fab
-                      color="#669617"
-                      @click="composeEmail('bcc')"
-                      :disabled="!selected.length"
-                    >
-                      bcc:
-                    </v-btn>
-                  </v-speed-dial>
-                </div>
-              </template>
-              <span>
-                Email selected users
-              </span>
-            </v-tooltip>
+            <IFXMailButton
+              v-model="recipientField"
+              :disabled="!selected.length"
+              toolTip="Email selected users"
+              @input="composeEmail()"
+            >
+            </IFXMailButton>
           </v-col>
         </v-row>
       </template>

--- a/src/entrypoint.js
+++ b/src/entrypoint.js
@@ -32,6 +32,7 @@ import IFXMailingDetail from '@/components/mailing/IFXMailingDetail'
 import IFXMailingList from '@/components/mailing/IFXMailingList'
 import IFXMailingMixin from '@/components/mailing/IFXMailingMixin'
 import IFXMailing from '@/components/mailing/IFXMailing'
+import IFXMailButton from '@/components/mailing/IFXMailButton'
 
 // Message
 import IFXMessageCreateEdit from '@/components/message/IFXMessageCreateEdit'
@@ -125,6 +126,7 @@ export {
   IFXMailingDetail,
   IFXMailingList,
   IFXMailingMixin,
+  IFXMailButton,
   IFXActionSelect,
   IFXDeleteItemButton,
   IFXMailing,


### PR DESCRIPTION
Email action list menu converted to IFXMailButton using a "speed dial" to select to: cc: bcc:
Fix "close" in IFXContactablesCombobox 
Fixed issue with "key" in IFXContactList: using id of Contact isn't quite right because id is repeated when there are multiple "roles" for the contact (actually "organizations").
Added a "computedName" to IFXContact to include the organization when contacts are repeated due to multiple roles
IFXMailingCompose takes "recipients" and "recipientField" as alternatives to explicit to, cc, bcc.  Should probably remove the latter.