### PR TITLE
Add skinny user API call

### DIFF
--- a/src/api/IFXAPI.js
+++ b/src/api/IFXAPI.js
@@ -346,6 +346,11 @@ export default class IFXAPIService {
     return api
   }
 
+  get skinnyUser() {
+    const baseUrl = this.urls.SKINNY_USERS
+    return this.genericAPI(baseUrl, User)
+  }
+
   get organization() {
     const baseUrl = this.urls.ORGANIZATIONS
     const createFunc = (orgData, decompose = false) => {

--- a/src/entrypoint.js
+++ b/src/entrypoint.js
@@ -68,7 +68,7 @@ import IFXUserEdit from '@/components/user/IFXUserEdit'
 import IFXUserDetail from '@/components/user/IFXUserDetail'
 import IFXUserList from '@/components/user/IFXUserList'
 import IFXUserMixin from '@/components/user/IFXUserMixin'
-import IFXUser from '@/components/user/IFXUser'
+import { User, UserContact, UserAccount } from '@/components/user/IFXUser'
 import IFXSelectableUser from '@/components/user/IFXSelectableUser'
 
 // Affiliation
@@ -155,7 +155,9 @@ export {
   IFXContactMixin,
   IFXSelectableContact,
   IFXContactCard,
-  IFXUser,
+  User,
+  UserContact,
+  UserAccount,
   IFXUserEdit,
   IFXUserDetail,
   IFXUserList,


### PR DESCRIPTION
This PR adds the `skinnyUser` API call which returns a subset of normal `User` data but is available to non-admins.

Also, changed what was exported to include User, UserContact, and UserAccount. Removed `IFXUser` since it isn't really used by anyone.