### PR TITLE
Add flag to include disabled to user api

### DIFF
--- a/src/components/item/IFXItemDetailMixin.js
+++ b/src/components/item/IFXItemDetailMixin.js
@@ -26,7 +26,7 @@ export default {
       return this.$api.auth.can(ability, user)
     },
     async init() {
-      this.item = await this.apiRef.getByID(this.id)
+      this.item = await this.apiRef.getByID(this.id, true)
     },
   },
   computed: {


### PR DESCRIPTION
This PR implements passing in an `includeDisabled` flag to `user.getByID` to include the `include_disabled` query param to get disabled users. This flag is on by default but can be turned off by passing in `false` as the second param. 