### PR TITLE
Billing record popup edit dialog

### DIFF
--- a/src/components/billingRecord/IFXBillingRecordDetail.vue
+++ b/src/components/billingRecord/IFXBillingRecordDetail.vue
@@ -61,7 +61,6 @@ export default {
         { text: 'Updated', value: 'updated', sortable: true },
       ],
       newExpenseCode: {},
-      currentDescription: '',
       expenseCodes: [],
     }
   },
@@ -155,7 +154,6 @@ export default {
     },
     updateRecord() {
       const newBillingRec = cloneDeep(this.item)
-      newBillingRec.description = this.currentDescription
       newBillingRec.account = this.newExpenseCode.data
 
       this.updateBillingRecord(newBillingRec)
@@ -402,9 +400,9 @@ export default {
                   <v-col cols="12">
                     <v-textarea
                       required
-                      v-model="currentDescription"
+                      v-model="item.description"
                       label="Billing Record description"
-                      :error-messages="errors[currentDescription]"
+                      :error-messages="errors[item.description]"
                       :rules="formRules.generic"
                       disabled
                     ></v-textarea>

--- a/src/components/billingRecord/IFXBillingRecordDetail.vue
+++ b/src/components/billingRecord/IFXBillingRecordDetail.vue
@@ -327,6 +327,9 @@ export default {
             <template v-slot:item.charge="{ item }">
               {{ item.charge | centsToDollars }}
             </template>
+            <template v-slot:item.rate="{ item }">
+              {{ item.rate | centsToDollars }}
+            </template>
           </v-data-table>
           <span v-else>None</span>
         </v-col>

--- a/src/components/billingRecord/IFXBillingRecordDetail.vue
+++ b/src/components/billingRecord/IFXBillingRecordDetail.vue
@@ -61,7 +61,7 @@ export default {
         { text: 'Updated', value: 'updated', sortable: true },
       ],
       newExpenseCode: {},
-      newDescription: '',
+      currentDescription: '',
       expenseCodes: [],
     }
   },
@@ -146,7 +146,6 @@ export default {
         this.expenseCodes = currentUserRecord.accounts
       }
 
-      this.newDescription = this.item.description
       this.newExpenseCode = this.$api.account.create(this.item.account)
 
       this.editDialog = true
@@ -156,7 +155,7 @@ export default {
     },
     updateRecord() {
       const newBillingRec = cloneDeep(this.item)
-      newBillingRec.description = this.newDescription
+      newBillingRec.description = this.currentDescription
       newBillingRec.account = this.newExpenseCode.data
 
       this.updateBillingRecord(newBillingRec)
@@ -372,7 +371,7 @@ export default {
 
             <v-card-actions>
               <v-spacer></v-spacer>
-              <v-btn color="blue darken-1" text @click="closeTxnDialog">Cancel</v-btn>
+              <v-btn color="secondary" text @click="closeTxnDialog">Cancel</v-btn>
               <v-btn color="blue darken-1" text :disabled="!isValid" @click="addNewTransaction(editedItem)">Save</v-btn>
             </v-card-actions>
           </v-card>
@@ -403,10 +402,11 @@ export default {
                   <v-col cols="12">
                     <v-textarea
                       required
-                      v-model="newDescription"
+                      v-model="currentDescription"
                       label="Billing Record description"
-                      :error-messages="errors[newDescription]"
+                      :error-messages="errors[currentDescription]"
                       :rules="formRules.generic"
+                      disabled
                     ></v-textarea>
                   </v-col>
                 </v-row>
@@ -414,7 +414,7 @@ export default {
             </v-card-text>
             <v-card-actions>
               <v-spacer></v-spacer>
-              <v-btn color="blue darken-1" text @click="closeEditDialog">Cancel</v-btn>
+              <v-btn color="secondary" text @click="closeEditDialog">Cancel</v-btn>
               <v-btn color="blue darken-1" text :disabled="!isValidEdit" @click="updateRecord">Save</v-btn>
             </v-card-actions>
           </v-card>

--- a/src/components/billingRecord/IFXBillingRecordList.vue
+++ b/src/components/billingRecord/IFXBillingRecordList.vue
@@ -509,6 +509,9 @@ export default {
     allowAddingTransactions(item) {
       return this.$api.auth.can('add-transactions', this.$api.authUser) && item.currentState !== 'FINAL'
     },
+    allowEditingRecords(item) {
+      return this.$api.auth.can('edit-records', this.$api.authUser) && item.currentState !== 'FINAL'
+    },
     notifyLabManagers() {
       const orgSlugs = this.items.map((item) => item.account.organization)
       this.$api.notifyLabManagers(
@@ -755,7 +758,7 @@ export default {
                 />
                 <IFXButton
                   class="ml-2"
-                  v-if="allowAddingTransactions(item)"
+                  v-if="allowEditingRecords(item)"
                   iconString="edit"
                   btnType="edit"
                   xSmall

--- a/src/components/billingRecord/IFXBillingRecordList.vue
+++ b/src/components/billingRecord/IFXBillingRecordList.vue
@@ -1,5 +1,6 @@
 <script>
 import { mapActions } from 'vuex'
+import cloneDeep from 'lodash/cloneDeep'
 
 import IFXBillingRecordMixin from '@/components/billingRecord/IFXBillingRecordMixin'
 import IFXButton from '@/components/IFXButton'
@@ -90,14 +91,17 @@ export default {
       tableCollpased: false,
       errors: [],
       search: null,
-      isValid: false,
-      dialog: false,
+      isValidTxn: false,
+      isValidEdit: false,
+      txnDialog: false,
+      editDialog: false,
       editedItem: {
         rate: 0,
         charge: 0,
         description: null,
         author: {},
         orgRec: {},
+        index: null,
       },
       defaultItem: {
         rate: 0,
@@ -107,6 +111,9 @@ export default {
       },
       mailFab: false,
       recipientField: '',
+      editedRecord: {},
+      expenseCodes: [],
+      editingIndex: null,
     }
   },
   computed: {
@@ -410,52 +417,81 @@ export default {
       this.rowSelectionToggleIndeterminate = {}
     },
     closeTxnDialog() {
-      this.dialog = false
+      this.txnDialog = false
     },
-    openTxnDialog(item) {
+    openTxnDialog(item, index) {
       this.editedItem = { ...this.defaultItem }
       this.editedItem.rate = item.rate
       this.editedItem.orgRec = item
+      this.editedItem.index = index
       this.editedItem.author = { ...this.$api.authUser }
       this.$nextTick(() => {
-        this.dialog = true
+        this.txnDialog = true
       })
     },
     addNewTransaction(item) {
-      const index = this.items.findIndex((rec) => rec.id === item.orgRec.id)
-      if (index !== -1) {
-        const orgBillingRec = this.items[index]
-        const { charge, rate, description, author } = item
-        const newTransactionData = {
-          charge,
-          rate,
-          description,
-          author,
-        }
-        const newTransaction = this.$api.billingTransaction.create(newTransactionData)
-        orgBillingRec.addTransaction(newTransaction)
-        this.updating = true
-        this.$api.billingRecord
-          .bulkUpdate([orgBillingRec], this.facility.applicationUsername)
-          .then((response) => {
-            this.updating = false
-            if (response.error) {
-              this.showMessage(response.error)
-            } else {
-              this.showMessage('Successfully updated billing record')
-            }
-            const newBillingRec = response.data[0]
-            this.items.splice(index, 1, newBillingRec)
-            this.dialog = false
-          })
-          .catch((error) => {
-            this.isLoading = false
-            this.updating = false
-            this.dialog = false
-            const message = this.getErrorMessage(error)
-            this.showMessage(message)
-          })
+      const orgBillingRec = item.orgRec
+      const { charge, rate, description, author } = item
+      const newTransactionData = {
+        charge,
+        rate,
+        description,
+        author,
       }
+      const newTransaction = this.$api.billingTransaction.create(newTransactionData)
+      orgBillingRec.addTransaction(newTransaction)
+      this.updateBillingRecord(orgBillingRec, item.index)
+    },
+    updateBillingRecord(newRecord, index) {
+      this.updating = true
+      this.$api.billingRecord
+        .bulkUpdate([newRecord], this.facility.applicationUsername)
+        .then((response) => {
+          if (response.error) {
+            this.showMessage(response.error)
+          } else {
+            this.showMessage('Successfully updated billing record')
+          }
+          const newBillingRec = response.data[0]
+          this.items.splice(index, 1, newBillingRec)
+        })
+        .catch((error) => {
+          this.isLoading = false
+          const message = this.getErrorMessage(error)
+          this.showMessage(message)
+        })
+        .finally(() => {
+          this.updating = false
+          this.txnDialog = false
+          this.editDialog = false
+        })
+    },
+    async openEditDialog(item, index) {
+      if (this.$api.auth.can('set-any-account', this.$api.authUser)) {
+        this.expenseCodes = await this.$api.account.getList()
+      } else {
+        const currentUserRecord = await this.$api.auth
+          .getCurrentUserRecord()
+          .catch(() => this.showMessage('Could not get user record. '))
+        this.expenseCodes = currentUserRecord.accounts
+      }
+
+      this.editingIndex = index
+      this.editedRecord = cloneDeep(item)
+      this.newExpenseCode = this.$api.account.create(item.account)
+
+      this.editDialog = true
+    },
+    closeEditDialog() {
+      this.editDialog = false
+      this.editedRecord = {}
+      this.editingIndex = null
+    },
+    updateSpecificRecord(billingRec) {
+      const newBillingRec = cloneDeep(billingRec)
+      newBillingRec.account = this.newExpenseCode.data
+      this.updateBillingRecord(newBillingRec, this.editingIndex)
+      this.closeEditDialog()
     },
     navigateToDetail(id) {
       this.rtr.push({
@@ -702,20 +738,30 @@ export default {
             <template v-slot:item.charge="{ item }">
               {{ item.charge | centsToDollars }}
             </template>
-            <template v-slot:item.actions="{ item }">
-              <IFXButton
-                v-if="allowAddingTransactions(item)"
-                iconString="add"
-                btnType="add"
-                xSmall
-                @action="openTxnDialog(item)"
-              />
+            <template v-slot:item.actions="{ item, index }">
+              <div class="d-flex flex-row">
+                <IFXButton
+                  v-if="allowAddingTransactions(item)"
+                  iconString="add"
+                  btnType="add"
+                  xSmall
+                  @action="openTxnDialog(item)"
+                />
+                <IFXButton
+                  class="ml-2"
+                  v-if="allowAddingTransactions(item)"
+                  iconString="edit"
+                  btnType="edit"
+                  xSmall
+                  @action="openEditDialog(item, index)"
+                />
+              </div>
             </template>
             <template v-slot:expanded-item="{ item }">
               <IFXBillingRecordTransactions :billingRecord="item" />
             </template>
           </v-data-table>
-          <v-dialog v-model="dialog" max-width="600px">
+          <v-dialog v-model="txnDialog" max-width="600px">
             <v-card>
               <v-card-title>
                 <span class="text-h5">Add a new transaction to Billing Record {{ editedItem.orgRec.id }}</span>
@@ -725,7 +771,7 @@ export default {
               </v-card-subtitle>
 
               <v-card-text>
-                <v-form v-model="isValid">
+                <v-form v-model="isValidTxn">
                   <v-row>
                     <v-col>
                       <v-currency-field
@@ -755,8 +801,51 @@ export default {
 
               <v-card-actions>
                 <v-spacer></v-spacer>
-                <v-btn color="blue darken-1" text @click="closeTxnDialog">Cancel</v-btn>
-                <v-btn color="blue darken-1" text :disabled="!isValid" @click="addNewTransaction(editedItem)">
+                <v-btn color="secondary" text @click="closeTxnDialog">Cancel</v-btn>
+                <v-btn color="blue darken-1" text :disabled="!isValidTxn" @click="addNewTransaction(editedItem)">
+                  Save
+                </v-btn>
+              </v-card-actions>
+            </v-card>
+          </v-dialog>
+          <v-dialog v-model="editDialog" max-width="600px">
+            <v-card>
+              <v-card-title>
+                <span class="text-h5">Edit Billing Record {{ editedRecord.id }}</span>
+              </v-card-title>
+              <v-card-text>
+                <v-form v-model="isValidEdit">
+                  <v-row>
+                    <v-col>
+                      <v-autocomplete
+                        required
+                        v-model="newExpenseCode"
+                        :items="expenseCodes"
+                        item-text="slug"
+                        item-value="slug"
+                        label="Expense Code / PO"
+                        :error-messages="errors[newExpenseCode]"
+                        :rules="formRules.generic"
+                        return-object
+                      ></v-autocomplete>
+                    </v-col>
+                    <v-col cols="12">
+                      <v-textarea
+                        required
+                        v-model="editedRecord.description"
+                        label="Billing Record description"
+                        :error-messages="errors[description]"
+                        :rules="formRules.generic"
+                        disabled
+                      ></v-textarea>
+                    </v-col>
+                  </v-row>
+                </v-form>
+              </v-card-text>
+              <v-card-actions>
+                <v-spacer></v-spacer>
+                <v-btn color="secondary" text @click="closeEditDialog">Cancel</v-btn>
+                <v-btn color="blue darken-1" text :disabled="!isValidEdit" @click="updateSpecificRecord(editedRecord)">
                   Save
                 </v-btn>
               </v-card-actions>

--- a/src/components/billingRecord/IFXBillingRecordTransactions.vue
+++ b/src/components/billingRecord/IFXBillingRecordTransactions.vue
@@ -38,6 +38,9 @@ export default {
       <template v-slot:item.charge="{ item }">
         {{ item.charge | centsToDollars }}
       </template>
+      <template v-slot:item.rate="{ item }">
+        {{ item.rate | centsToDollars }}
+      </template>
     </v-data-table>
   </td>
 </template>


### PR DESCRIPTION
This PR implements a popup edit dialog on the main IFXBillingRecordList component. It is similar to the transaction dialog and allows the user to change the expense code/PO of that record.

In both this dialog and the one on the detail page, we disable the description as it is auto-generated.

Other minor tweaks are displaying the rate in dollars and cents and changing the color of the cancel buttons in both dialogs.
