### PR TITLE
Improve performance of handling checkboxes and add summary details

### DIFF
--- a/src/api/IFXAPI.js
+++ b/src/api/IFXAPI.js
@@ -798,6 +798,8 @@ export default class IFXAPIService {
         newBillingData.transactions = transactionDataObjs
       }
 
+      newBillingData.organization = data.account?.organization
+
       return decompose ? newBillingData : new BillingRecord(newBillingData)
     }
     const decomposeFunc = (billingRecord) => createFunc(billingRecord, true)

--- a/src/components/billingRecord/IFXBillingRecordHeader.vue
+++ b/src/components/billingRecord/IFXBillingRecordHeader.vue
@@ -99,7 +99,7 @@ export default {
     <v-row v-if="showSummaryDetail">
       <v-col class="py-1 ml-9">
         <v-row v-for="entry in summaryDetails" :key="`${group}-${entry[0]}`" class="text-body-2">
-          <v-col class="ml-3">{{entry[0]}}</v-col><v-col class="ml-3 font-weight-medium">{{ entry[1] | centsToDollars}} </v-col><v-spacer></v-spacer>
+          <v-col cols="5" class="ml-3">{{entry[0]}}</v-col><v-col class="text-xs-left ml-3 font-weight-medium">{{ entry[1] | centsToDollars}} </v-col>
         </v-row>
       </v-col>
     </v-row>

--- a/src/components/billingRecord/IFXBillingRecordHeader.vue
+++ b/src/components/billingRecord/IFXBillingRecordHeader.vue
@@ -68,16 +68,12 @@ export default {
       }
       this.showSummaryDetail = !this.showSummaryDetail
     },
-    logIt(content) {
-      console.log(content)
-    }
   },
   watch: {},
 }
 </script>
 <template>
   <td :colspan="colSpan" class="py-2">
-    <!-- {{ logIt(`group header for ${group}`)}} -->
     <v-row>
       <v-checkbox
         v-if="showCheckboxes"

--- a/src/components/billingRecord/IFXBillingRecordHeader.vue
+++ b/src/components/billingRecord/IFXBillingRecordHeader.vue
@@ -38,32 +38,46 @@ export default {
       type: Number,
       required: true,
     },
+    getSummaryDetails: {
+      type: Function,
+      required: true,
+    },
   },
   mounted() {
     this.localRowSelectionToggle = this.rowSelectionToggle.concat()
   },
   data() {
     return {
-      localRowSelectionToggle: []
+      localRowSelectionToggle: [],
+      showSummaryDetail: false,
+      summaryButtonText: 'Show',
+      summaryDetails: []
     }
   },
   computed: {},
   methods: {
-    syncData(group) {
+    syncData() {
       this.$emit('update:row-selection-toggle', this.localRowSelectionToggle)
       this.$emit('update:row-selection-toggle-indeterminate', this.rowSelectionToggleIndeterminateGroup)
-      this.toggleGroup(group)
+      this.toggleGroup(this.group)
     },
-    // logIt(content) {
-    //   console.log(content)
-    // }
+    toggleSummaryDetail() {
+      this.summaryButtonText = this.showSummaryDetail ? 'Show' : 'Hide'
+      if (!this.showSummaryDetail && this.summaryDetails.length === 0) {
+        this.summaryDetails = Array.from(this.getSummaryDetails(this.group).entries())
+      }
+      this.showSummaryDetail = !this.showSummaryDetail
+    },
+    logIt(content) {
+      console.log(content)
+    }
   },
   watch: {},
 }
 </script>
 <template>
-  <td :colspan="colSpan">
-    <!-- {{ logIt('group header')}} -->
+  <td :colspan="colSpan" class="py-2">
+    <!-- {{ logIt(`group header for ${group}`)}} -->
     <v-row>
       <v-checkbox
         v-if="showCheckboxes"
@@ -73,18 +87,31 @@ export default {
         multiple
         :indeterminate.sync="rowSelectionToggleIndeterminateGroup"
         class="shrink ml-3 mt-0"
-        @change="syncData(group)"
+        @change="syncData()"
       ></v-checkbox>
       <div>
         <v-btn icon small @click="toggle">
-          <v-icon>{{ isOpen ? 'mdi-menu-down' : 'mdi-menu-right' }}</v-icon>
+          <v-icon :class="{'active' : isOpen}">mdi-menu-right</v-icon>
         </v-btn>
         <span class="group-header">
           {{ $api.organization.parseSlug(group).name }}
         </span>
         <span class="ml-3 font-weight-medium">Total charges: {{ summaryCharges | centsToDollars }}</span>
+        <v-btn small text @click="toggleSummaryDetail" class="ml-2">{{summaryButtonText}} Detail</v-btn>
       </div>
+    </v-row>
+    <v-row v-if="showSummaryDetail">
+      <v-col class="py-1 ml-9">
+        <div v-for="entry in summaryDetails" :key="`${group}-${entry[0]}`" class="text-body-2">
+          <span>{{entry[0]}}:</span><span class="ml-3 font-weight-medium">{{ entry[1] | centsToDollars}} </span>
+        </div>
+      </v-col>
     </v-row>
   </td>
 </template>
-<style scoped lang="scss"></style>
+<style scoped lang="scss">
+.active {
+  -webkit-transform: rotate(90deg);
+  transform: rotate(90deg);
+}
+</style>

--- a/src/components/billingRecord/IFXBillingRecordHeader.vue
+++ b/src/components/billingRecord/IFXBillingRecordHeader.vue
@@ -1,0 +1,90 @@
+<script>
+export default {
+  name: 'IFXBillingRecordHeader',
+  props: {
+    group: {
+      type: String,
+      required: true,
+    },
+    headers: {
+      type: Array,
+      required: true,
+    },
+    isOpen: {
+      type: Boolean,
+      required: true,
+    },
+    showCheckboxes: {
+      type: Boolean,
+      required: true,
+    },
+    toggle: {
+      type: Function,
+      required: true,
+    },
+    toggleGroup: {
+      type: Function,
+      required: true,
+    },
+    rowSelectionToggleGroup: {
+      type: String,
+      required: false,
+    },
+    rowSelectionToggleIndeterminateGroup: {
+      type: Boolean,
+      required: false,
+    },
+    summaryCharges: {
+      type: Number,
+      required: true,
+    },
+  },
+  mounted() {
+    this.localRowSelectionToggleGroup = this.rowSelectionToggleGroup
+  },
+  data() {
+    return {
+      localRowSelectionToggle: []
+    }
+  },
+  computed: {},
+  methods: {
+    syncData() {
+      this.$emit('update:row-selection-toggle', this.localRowSelectionToggleGroup)
+      this.$emit('update:row-selection-toggle-indeterminate', this.rowSelectionToggleIndeterminateGroup)
+    },
+    foo(content) {
+      console.log(content)
+    }
+  },
+  watch: {},
+}
+</script>
+<template>
+  <td :colspan="headers.length">
+    {{ foo('group header')}}
+    <v-row>
+      <v-checkbox
+        v-if="showCheckboxes"
+        v-model="localRowSelectionToggleGroup"
+        :value="group"
+        hide-details
+        multiple
+        :indeterminate.sync="rowSelectionToggleIndeterminateGroup"
+        class="shrink ml-3 mt-0"
+        @change="syncData"
+        @click="toggleGroup(group)"
+      ></v-checkbox>
+      <div>
+        <v-btn icon small @click="toggle">
+          <v-icon>{{ isOpen ? 'mdi-menu-down' : 'mdi-menu-right' }}</v-icon>
+        </v-btn>
+        <span class="group-header">
+          {{ $api.organization.parseSlug(group).name }}
+        </span>
+        <span class="ml-3 font-weight-medium">Total charges: {{ summaryCharges | centsToDollars }}</span>
+      </div>
+    </v-row>
+  </td>
+</template>
+<style scoped lang="scss"></style>

--- a/src/components/billingRecord/IFXBillingRecordHeader.vue
+++ b/src/components/billingRecord/IFXBillingRecordHeader.vue
@@ -6,8 +6,8 @@ export default {
       type: String,
       required: true,
     },
-    headers: {
-      type: Array,
+    colSpan: {
+      type: Number,
       required: true,
     },
     isOpen: {
@@ -26,8 +26,8 @@ export default {
       type: Function,
       required: true,
     },
-    rowSelectionToggleGroup: {
-      type: String,
+    rowSelectionToggle: {
+      type: Array,
       required: false,
     },
     rowSelectionToggleIndeterminateGroup: {
@@ -40,7 +40,7 @@ export default {
     },
   },
   mounted() {
-    this.localRowSelectionToggleGroup = this.rowSelectionToggleGroup
+    this.localRowSelectionToggle = this.rowSelectionToggle.concat()
   },
   data() {
     return {
@@ -49,31 +49,31 @@ export default {
   },
   computed: {},
   methods: {
-    syncData() {
-      this.$emit('update:row-selection-toggle', this.localRowSelectionToggleGroup)
+    syncData(group) {
+      this.$emit('update:row-selection-toggle', this.localRowSelectionToggle)
       this.$emit('update:row-selection-toggle-indeterminate', this.rowSelectionToggleIndeterminateGroup)
+      this.toggleGroup(group)
     },
-    foo(content) {
-      console.log(content)
-    }
+    // logIt(content) {
+    //   console.log(content)
+    // }
   },
   watch: {},
 }
 </script>
 <template>
-  <td :colspan="headers.length">
-    {{ foo('group header')}}
+  <td :colspan="colSpan">
+    <!-- {{ logIt('group header')}} -->
     <v-row>
       <v-checkbox
         v-if="showCheckboxes"
-        v-model="localRowSelectionToggleGroup"
+        v-model="localRowSelectionToggle"
         :value="group"
         hide-details
         multiple
         :indeterminate.sync="rowSelectionToggleIndeterminateGroup"
         class="shrink ml-3 mt-0"
-        @change="syncData"
-        @click="toggleGroup(group)"
+        @change="syncData(group)"
       ></v-checkbox>
       <div>
         <v-btn icon small @click="toggle">

--- a/src/components/billingRecord/IFXBillingRecordList.vue
+++ b/src/components/billingRecord/IFXBillingRecordList.vue
@@ -377,6 +377,19 @@ export default {
       const summary = records.reduce((prev, current) => prev + current.charge, 0)
       return summary
     },
+    getSummaryDetails(group) {
+      const records = this.filteredItems.filter((item) => item.account.organization === group)
+      const expenseMap = new Map()
+      records.forEach((item) => {
+        if (expenseMap.has(item.account.slug)) {
+          const value = expenseMap.get(item.account.slug)
+          expenseMap.set(item.account.slug, value + item.charge)
+        } else {
+          expenseMap.set(item.account.slug, item.charge)
+        }
+      })
+      return expenseMap
+    },
     determineGroupState(e) {
       const group = e.item.account.organization
       const records = this.filteredItems.filter((item) => item.account.organization === group)
@@ -731,6 +744,7 @@ export default {
               v-on:rendered="itemRendered('group.header')"
             >
                 <IFXBillingRecordHeader
+                :key="group"
                 :item="item"
                 :group="group"
                 :colSpan="headers.length"
@@ -741,6 +755,7 @@ export default {
                 :rowSelectionToggleIndeterminateGroup.sync="rowSelectionToggleIndeterminate[group]"
                 :summaryCharges="summaryCharges(group)"
                 :toggleGroup="toggleGroup"
+                :getSummaryDetails="getSummaryDetails"
                 @
               />
               <!-- <template v-slot:group.header="{ group, headers, isOpen, toggle }">
@@ -937,7 +952,4 @@ export default {
 }
 </style>
 <style>
-.input-group--selection-controls__ripple {
-  border-radius: 0 !important;
-}
 </style>

--- a/src/components/billingRecord/IFXBillingRecordList.vue
+++ b/src/components/billingRecord/IFXBillingRecordList.vue
@@ -354,11 +354,8 @@ export default {
         })
     },
     toggleGroup(group) {
-      // console.log(new Date().getTime())
       const records = this.filteredItems.filter((item) => item.account.organization === group)
-      // console.log(new Date().getTime())
       const isSelected = this.rowSelectionToggle.indexOf(group) !== -1
-      // const isSelected = e.value
       records.forEach((record) => {
         const index = this.selected.findIndex((item) => record.id === item.id)
         if (index !== -1) {
@@ -369,7 +366,6 @@ export default {
           this.selected.push(record)
         }
       })
-      // console.log(new Date().getTime())
       this.$set(this.rowSelectionToggleIndeterminate, group, false)
     },
     summaryCharges(group) {
@@ -393,13 +389,8 @@ export default {
     determineGroupState(e) {
       const group = e.item.account.organization
       const records = this.filteredItems.filter((item) => item.account.organization === group)
-      // console.log(new Date().getTime(), records.length)
       let checked = this.selected.filter((item) => item.account.organization === group).length
-      // console.log(new Date().getTime(), checked, this.selected.length)
       checked += e.value ? 1 : -1
-      // console.log(new Date().getTime(), checked, this.selected.length)
-      // this.$nextTick(() => {
-      // console.log(new Date().getTime(), checked, this.selected.length)
       const state = checked !== 0 && checked < records.length
       this.$set(this.rowSelectionToggleIndeterminate, group, state)
       // Now set the checkbox model to the correct state
@@ -418,15 +409,12 @@ export default {
           this.rowSelectionToggle.splice(index, 1)
         }
       }
-      // console.log(new Date().getTime(), 'done')
-      // })
     },
     toggleSelectAll({ items, value }) {
       const orgSet = new Set()
       items.forEach((item) => {
         orgSet.add(item.account.organization)
       })
-      // this.$nextTick(() => {
       if (value) {
         // The user selected all records. Set all the checkboxes on
         this.rowSelectionToggle = Array.from(orgSet)
@@ -436,7 +424,6 @@ export default {
       }
       // And clear indeterminate state
       this.$set(this.rowSelectionToggleIndeterminate, Array.from(orgSet), false)
-      // })
     },
     collpaseRows() {
       // This is a bit of a hack to collpase the group sections when the table loads
@@ -563,10 +550,6 @@ export default {
         this.recipientField,
         this.$router
       )
-    },
-    foo(content) {
-      console.log(content)
-      return content
     },
   },
   watch: {
@@ -758,34 +741,6 @@ export default {
                 :getSummaryDetails="getSummaryDetails"
                 @
               />
-              <!-- <template v-slot:group.header="{ group, headers, isOpen, toggle }">
-                <td :colspan="headers.length">
-                  {{ foo('group header') }}
-
-                  <v-row>
-                    <v-checkbox
-                      v-if="showCheckboxes"
-                      v-model="rowSelectionToggle"
-                      :value="group"
-                      hide-details
-                      multiple
-                      :indeterminate.sync="rowSelectionToggleIndeterminate[group]"
-                      class="shrink ml-3 mt-0"
-                      @click="toggleGroup(group)"
-                    ></v-checkbox>
-                    <div>
-                      <v-btn icon small @click="toggle">
-                        <v-icon>{{ isOpen ? 'mdi-menu-down' : 'mdi-menu-right' }}</v-icon>
-                      </v-btn>
-                      <span class="group-header">
-                        {{ $api.organization.parseSlug(group).name }}
-                      </span>
-                      <span class="ml-3 font-weight-medium">
-                        Total charges: {{ summaryCharges(group) | centsToDollars }}
-                      </span>
-                    </div>
-                  </v-row>
-                </td> -->
               </template>
             <template v-slot:item.id="{ item }">
               <a href="" @click.prevent="navigateToDetail(item.id)">{{ item.id }}</a>
@@ -950,6 +905,4 @@ export default {
   -webkit-box-shadow: none;
   box-shadow: none;
 }
-</style>
-<style>
 </style>

--- a/src/components/billingRecord/IFXBillingRecordList.vue
+++ b/src/components/billingRecord/IFXBillingRecordList.vue
@@ -254,8 +254,32 @@ export default {
       this.clearTableState()
       return this.$api.billingRecord
         .getList(this.facility.invoicePrefix, this.month, this.year, this.organization)
-        .then((res) => (this.items = res))
+        .then((res) => {
+          this.items = res.concat()
+          // let bump = 0
+          // this.items = this.items.concat(this.dupRecords(res, bump += 1000))
+          // this.items = this.items.concat(this.dupRecords(res, bump += 1000))
+          // this.items = this.items.concat(this.dupRecords(res, bump += 1000))
+          // this.items = this.items.concat(this.dupRecords(res, bump += 1000))
+          // this.items = this.items.concat(this.dupRecords(res, bump += 1000))
+          // this.items = this.items.concat(this.dupRecords(res, bump += 1000))
+          // this.items = this.items.concat(this.dupRecords(res, bump += 1000))
+          // this.items = this.items.concat(this.dupRecords(res, bump += 1000))
+          // this.items = this.items.concat(this.dupRecords(res, bump += 1000))
+          // this.items = this.items.concat(this.dupRecords(res, bump += 1000))
+          // this.items = this.items.concat(this.dupRecords(res, bump += 1000))
+          // this.items = this.items.concat(this.dupRecords(res, bump += 1000))
+          // this.items = this.items.concat(this.dupRecords(res, bump += 1000))
+        })
     },
+    // dupRecords(res, bump) {
+    //   const foo = res.map(item => {
+    //     const newItem = cloneDeep(item)
+    //     newItem._data.id += bump
+    //     return newItem
+    //   })
+    //   return foo
+    // },
     setState(items, state) {
       items.forEach((s) => {
         s.billingRecordStates.push({ name: state, user: '', approvers: [], comment: '' })
@@ -338,7 +362,9 @@ export default {
         })
     },
     toggleGroup(group) {
+      // console.log(new Date().getTime())
       const records = this.filteredItems.filter((item) => item.account.organization === group)
+      // console.log(new Date().getTime())
       const isSelected = this.rowSelectionToggle.indexOf(group) !== -1
       records.forEach((record) => {
         const index = this.selected.findIndex((item) => record.id === item.id)
@@ -350,6 +376,7 @@ export default {
           this.selected.push(record)
         }
       })
+      // console.log(new Date().getTime())
       this.$set(this.rowSelectionToggleIndeterminate, group, false)
     },
     summaryCharges(group) {
@@ -359,45 +386,49 @@ export default {
     },
     determineGroupState(e) {
       const group = e.item.account.organization
-      this.$nextTick(() => {
-        const records = this.filteredItems.filter((item) => item.account.organization === group)
-        const checked = this.selected.filter((item) => item.account.organization === group)
-        const state = checked.length !== 0 && checked.length < records.length
-        this.$set(this.rowSelectionToggleIndeterminate, group, state)
-        // Now set the checkbox model to the correct state
-        if (checked.length) {
-          if (checked.length === records.length) {
-            // All are checked so add this if it isn't already there
-            const index = this.rowSelectionToggle.indexOf(group)
-            if (index === -1) {
-              this.rowSelectionToggle.push(group)
-            }
-          }
-        } else {
-          // None are checked so remove this group
+      const records = this.filteredItems.filter((item) => item.account.organization === group)
+      let checked = this.selected.filter((item) => item.account.organization === group).length
+      // console.log(new Date().getTime(), checked, this.selected.length)
+      checked += e.value ? 1 : -1
+      // console.log(new Date().getTime(), checked, this.selected.length)
+      // this.$nextTick(() => {
+      // console.log(new Date().getTime(), checked, this.selected.length)
+      const state = checked !== 0 && checked < records.length
+      this.$set(this.rowSelectionToggleIndeterminate, group, state)
+      // Now set the checkbox model to the correct state
+      if (checked) {
+        if (checked === records.length) {
+          // All are checked so add this if it isn't already there
           const index = this.rowSelectionToggle.indexOf(group)
-          if (index !== -1) {
-            this.rowSelectionToggle.splice(index, 1)
+          if (index === -1) {
+            this.rowSelectionToggle.push(group)
           }
         }
-      })
+      } else {
+        // None are checked so remove this group
+        const index = this.rowSelectionToggle.indexOf(group)
+        if (index !== -1) {
+          this.rowSelectionToggle.splice(index, 1)
+        }
+      }
+      // })
     },
     toggleSelectAll({ items, value }) {
       const orgSet = new Set()
       items.forEach((item) => {
         orgSet.add(item.account.organization)
       })
-      this.$nextTick(() => {
-        if (value) {
-          // The user selected all records. Set all the checkboxes on
-          this.rowSelectionToggle = Array.from(orgSet)
-        } else {
-          // They've cleared all records. Remove all orgs from the array
-          this.rowSelectionToggle = []
-        }
-        // And clear indeterminate state
-        this.$set(this.rowSelectionToggleIndeterminate, Array.from(orgSet), false)
-      })
+      // this.$nextTick(() => {
+      if (value) {
+        // The user selected all records. Set all the checkboxes on
+        this.rowSelectionToggle = Array.from(orgSet)
+      } else {
+        // They've cleared all records. Remove all orgs from the array
+        this.rowSelectionToggle = []
+      }
+      // And clear indeterminate state
+      this.$set(this.rowSelectionToggleIndeterminate, Array.from(orgSet), false)
+      // })
     },
     collpaseRows() {
       // This is a bit of a hack to collpase the group sections when the table loads

--- a/src/components/billingRecord/IFXBillingRecordList.vue
+++ b/src/components/billingRecord/IFXBillingRecordList.vue
@@ -6,7 +6,8 @@ import IFXBillingRecordMixin from '@/components/billingRecord/IFXBillingRecordMi
 import IFXButton from '@/components/IFXButton'
 import IFXSearchField from '@/components/IFXSearchField'
 import IFXMailButton from '@/components/mailing/IFXMailButton'
-import IFXBillingRecordTransactions from './IFXBillingRecordTransactions'
+// import IFXBillingRecordHeader from '@/components/billingRecord/IFXBillingRecordHeader'
+// import IFXBillingRecordTransactions from './IFXBillingRecordTransactions'
 
 export default {
   name: 'IFXBillingRecordList',
@@ -14,8 +15,9 @@ export default {
     // IFXItemDataTable,
     IFXButton,
     IFXSearchField,
-    IFXBillingRecordTransactions,
+    // IFXBillingRecordTransactions,
     IFXMailButton,
+    // IFXBillingRecordHeader
   },
   mixins: [IFXBillingRecordMixin],
   filters: {
@@ -268,32 +270,8 @@ export default {
       this.clearTableState()
       return this.$api.billingRecord
         .getList(this.facility.invoicePrefix, this.month, this.year, this.organization)
-        .then((res) => {
-          this.items = res.concat()
-          // let bump = 0
-          // this.items = this.items.concat(this.dupRecords(res, bump += 1000))
-          // this.items = this.items.concat(this.dupRecords(res, bump += 1000))
-          // this.items = this.items.concat(this.dupRecords(res, bump += 1000))
-          // this.items = this.items.concat(this.dupRecords(res, bump += 1000))
-          // this.items = this.items.concat(this.dupRecords(res, bump += 1000))
-          // this.items = this.items.concat(this.dupRecords(res, bump += 1000))
-          // this.items = this.items.concat(this.dupRecords(res, bump += 1000))
-          // this.items = this.items.concat(this.dupRecords(res, bump += 1000))
-          // this.items = this.items.concat(this.dupRecords(res, bump += 1000))
-          // this.items = this.items.concat(this.dupRecords(res, bump += 1000))
-          // this.items = this.items.concat(this.dupRecords(res, bump += 1000))
-          // this.items = this.items.concat(this.dupRecords(res, bump += 1000))
-          // this.items = this.items.concat(this.dupRecords(res, bump += 1000))
-        })
+        .then((res) => (this.items = res))
     },
-    // dupRecords(res, bump) {
-    //   const foo = res.map(item => {
-    //     const newItem = cloneDeep(item)
-    //     newItem._data.id += bump
-    //     return newItem
-    //   })
-    //   return foo
-    // },
     setState(items, state) {
       items.forEach((s) => {
         s.billingRecordStates.push({ name: state, user: '', approvers: [], comment: '' })
@@ -401,10 +379,11 @@ export default {
     determineGroupState(e) {
       const group = e.item.account.organization
       const records = this.filteredItems.filter((item) => item.account.organization === group)
+      console.log(new Date().getTime(), records.length)
       let checked = this.selected.filter((item) => item.account.organization === group).length
-      // console.log(new Date().getTime(), checked, this.selected.length)
+      console.log(new Date().getTime(), checked, this.selected.length)
       checked += e.value ? 1 : -1
-      // console.log(new Date().getTime(), checked, this.selected.length)
+      console.log(new Date().getTime(), checked, this.selected.length)
       // this.$nextTick(() => {
       // console.log(new Date().getTime(), checked, this.selected.length)
       const state = checked !== 0 && checked < records.length
@@ -425,6 +404,7 @@ export default {
           this.rowSelectionToggle.splice(index, 1)
         }
       }
+      console.log(new Date().getTime(), 'done')
       // })
     },
     toggleSelectAll({ items, value }) {
@@ -569,6 +549,10 @@ export default {
         this.recipientField,
         this.$router
       )
+    },
+    foo(content) {
+      console.log(content)
+      return content
     },
   },
   watch: {
@@ -725,50 +709,71 @@ export default {
       </v-card-title>
       <v-row>
         <v-col id="data-table">
-          <v-data-table
-            ref="table"
-            v-if="filteredItems"
-            v-model="selected"
-            :items="filteredItems"
-            :headers="headers"
-            :show-select="showCheckboxes"
-            show-expand
-            expand-icon="mdi-menu-right"
-            :itemKey="itemKey"
-            :loading="isLoading"
-            :items-per-page="-1"
-            group-by="account.organization"
-            @item-selected="determineGroupState"
-            @toggle-select-all="toggleSelectAll"
-          >
-            <template v-slot:group.header="{ group, headers, isOpen, toggle }">
-              <td :colspan="headers.length">
-                <v-row>
-                  <v-checkbox
-                    v-if="showCheckboxes"
-                    v-model="rowSelectionToggle"
-                    :value="group"
-                    hide-details
-                    multiple
-                    :indeterminate.sync="rowSelectionToggleIndeterminate[group]"
-                    class="shrink ml-3 mt-0"
-                    @click="toggleGroup(group)"
-                  ></v-checkbox>
-                  <div>
-                    <v-btn icon small @click="toggle">
-                      <v-icon>{{ isOpen ? 'mdi-menu-down' : 'mdi-menu-right' }}</v-icon>
-                    </v-btn>
-                    <span class="group-header">
-                      {{ $api.organization.parseSlug(group).name }}
-                    </span>
-                    <span class="ml-3 font-weight-medium">
-                      Total charges: {{ summaryCharges(group) | centsToDollars }}
-                    </span>
-                  </div>
-                </v-row>
-              </td>
-            </template>
-            <template v-slot:item.id="{ item }">
+            <v-data-table
+              ref="table"
+              v-if="filteredItems"
+              v-model="selected"
+              :items="filteredItems"
+              :headers="headers"
+              :show-select="showCheckboxes"
+              show-expand
+              expand-icon="mdi-menu-right"
+              :itemKey="itemKey"
+              :loading="isLoading"
+              :items-per-page="-1"
+              xxgroup-by="account.organization"
+              @xxitem-selected="determineGroupState"
+              @xxtoggle-select-all="toggleSelectAll"
+            >
+              <!-- <template
+              v-slot:group.header="{ group, headers, isOpen, toggle }"
+              xxv-on:rendered="itemRendered('group.header')"
+            >
+                <IFXBillingRecordHeader
+                :item="item"
+                :group="group"
+                :headers="headers"
+                :isOpen="isOpen"
+                :showCheckboxes="showCheckboxes"
+                :toggle="toggle"
+                :xxrowSelectionToggleGroup.sync="rowSelectionToggle[group]"
+                :xxrowSelectionToggleIndeterminateGroup.sync="rowSelectionToggleIndeterminate[group]"
+                rowSelectionToggleGroup="rowSelectionToggle[group]"
+                :rowSelectionToggleIndeterminateGroup="true"
+                :summaryCharges="summaryCharges(group)"
+                :toggleGroup="toggleGroup"
+                @
+              /> -->
+              <!-- <template v-slot:group.header="{ group, headers, isOpen, toggle }">
+                <td :colspan="headers.length">
+                  {{ foo('group header') }}
+
+                  <v-row>
+                    <v-checkbox
+                      v-if="showCheckboxes"
+                      v-model="rowSelectionToggle"
+                      :value="group"
+                      hide-details
+                      multiple
+                      :indeterminate.sync="rowSelectionToggleIndeterminate[group]"
+                      class="shrink ml-3 mt-0"
+                      @click="toggleGroup(group)"
+                    ></v-checkbox>
+                    <div>
+                      <v-btn icon small @click="toggle">
+                        <v-icon>{{ isOpen ? 'mdi-menu-down' : 'mdi-menu-right' }}</v-icon>
+                      </v-btn>
+                      <span class="group-header">
+                        {{ $api.organization.parseSlug(group).name }}
+                      </span>
+                      <span class="ml-3 font-weight-medium">
+                        Total charges: {{ summaryCharges(group) | centsToDollars }}
+                      </span>
+                    </div>
+                  </v-row>
+                </td> -->
+              <!-- </template> -->
+              <!-- <template v-slot:item.id="{ item }">
               <a href="" @click.prevent="navigateToDetail(item.id)">{{ item.id }}</a>
             </template>
 
@@ -815,8 +820,8 @@ export default {
             </template>
             <template v-slot:expanded-item="{ item }">
               <IFXBillingRecordTransactions :billingRecord="item" />
-            </template>
-          </v-data-table>
+            </template> -->
+            </v-data-table>
           <v-dialog v-model="txnDialog" max-width="600px">
             <v-card>
               <v-card-title>
@@ -930,5 +935,10 @@ export default {
 #data-table .v-data-table > .v-data-table__wrapper tbody tr.v-data-table__expanded__content {
   -webkit-box-shadow: none;
   box-shadow: none;
+}
+</style>
+<style>
+.input-group--selection-controls__ripple {
+  border-radius: 0 !important;
 }
 </style>

--- a/src/components/billingRecord/IFXBillingRecordList.vue
+++ b/src/components/billingRecord/IFXBillingRecordList.vue
@@ -6,8 +6,8 @@ import IFXBillingRecordMixin from '@/components/billingRecord/IFXBillingRecordMi
 import IFXButton from '@/components/IFXButton'
 import IFXSearchField from '@/components/IFXSearchField'
 import IFXMailButton from '@/components/mailing/IFXMailButton'
-// import IFXBillingRecordHeader from '@/components/billingRecord/IFXBillingRecordHeader'
-// import IFXBillingRecordTransactions from './IFXBillingRecordTransactions'
+import IFXBillingRecordHeader from '@/components/billingRecord/IFXBillingRecordHeader'
+import IFXBillingRecordTransactions from './IFXBillingRecordTransactions'
 
 export default {
   name: 'IFXBillingRecordList',
@@ -15,9 +15,9 @@ export default {
     // IFXItemDataTable,
     IFXButton,
     IFXSearchField,
-    // IFXBillingRecordTransactions,
+    IFXBillingRecordTransactions,
     IFXMailButton,
-    // IFXBillingRecordHeader
+    IFXBillingRecordHeader
   },
   mixins: [IFXBillingRecordMixin],
   filters: {
@@ -358,6 +358,7 @@ export default {
       const records = this.filteredItems.filter((item) => item.account.organization === group)
       // console.log(new Date().getTime())
       const isSelected = this.rowSelectionToggle.indexOf(group) !== -1
+      // const isSelected = e.value
       records.forEach((record) => {
         const index = this.selected.findIndex((item) => record.id === item.id)
         if (index !== -1) {
@@ -379,11 +380,11 @@ export default {
     determineGroupState(e) {
       const group = e.item.account.organization
       const records = this.filteredItems.filter((item) => item.account.organization === group)
-      console.log(new Date().getTime(), records.length)
+      // console.log(new Date().getTime(), records.length)
       let checked = this.selected.filter((item) => item.account.organization === group).length
-      console.log(new Date().getTime(), checked, this.selected.length)
+      // console.log(new Date().getTime(), checked, this.selected.length)
       checked += e.value ? 1 : -1
-      console.log(new Date().getTime(), checked, this.selected.length)
+      // console.log(new Date().getTime(), checked, this.selected.length)
       // this.$nextTick(() => {
       // console.log(new Date().getTime(), checked, this.selected.length)
       const state = checked !== 0 && checked < records.length
@@ -404,7 +405,7 @@ export default {
           this.rowSelectionToggle.splice(index, 1)
         }
       }
-      console.log(new Date().getTime(), 'done')
+      // console.log(new Date().getTime(), 'done')
       // })
     },
     toggleSelectAll({ items, value }) {
@@ -721,29 +722,27 @@ export default {
               :itemKey="itemKey"
               :loading="isLoading"
               :items-per-page="-1"
-              xxgroup-by="account.organization"
-              @xxitem-selected="determineGroupState"
-              @xxtoggle-select-all="toggleSelectAll"
+              group-by="account.organization"
+              @item-selected="determineGroupState"
+              @toggle-select-all="toggleSelectAll"
             >
-              <!-- <template
+              <template
               v-slot:group.header="{ group, headers, isOpen, toggle }"
-              xxv-on:rendered="itemRendered('group.header')"
+              v-on:rendered="itemRendered('group.header')"
             >
                 <IFXBillingRecordHeader
                 :item="item"
                 :group="group"
-                :headers="headers"
+                :colSpan="headers.length"
                 :isOpen="isOpen"
                 :showCheckboxes="showCheckboxes"
                 :toggle="toggle"
-                :xxrowSelectionToggleGroup.sync="rowSelectionToggle[group]"
-                :xxrowSelectionToggleIndeterminateGroup.sync="rowSelectionToggleIndeterminate[group]"
-                rowSelectionToggleGroup="rowSelectionToggle[group]"
-                :rowSelectionToggleIndeterminateGroup="true"
+                :rowSelectionToggle.sync="rowSelectionToggle"
+                :rowSelectionToggleIndeterminateGroup.sync="rowSelectionToggleIndeterminate[group]"
                 :summaryCharges="summaryCharges(group)"
                 :toggleGroup="toggleGroup"
                 @
-              /> -->
+              />
               <!-- <template v-slot:group.header="{ group, headers, isOpen, toggle }">
                 <td :colspan="headers.length">
                   {{ foo('group header') }}
@@ -772,8 +771,8 @@ export default {
                     </div>
                   </v-row>
                 </td> -->
-              <!-- </template> -->
-              <!-- <template v-slot:item.id="{ item }">
+              </template>
+            <template v-slot:item.id="{ item }">
               <a href="" @click.prevent="navigateToDetail(item.id)">{{ item.id }}</a>
             </template>
 
@@ -820,7 +819,7 @@ export default {
             </template>
             <template v-slot:expanded-item="{ item }">
               <IFXBillingRecordTransactions :billingRecord="item" />
-            </template> -->
+            </template>
             </v-data-table>
           <v-dialog v-model="txnDialog" max-width="600px">
             <v-card>


### PR DESCRIPTION
This PR slightly improves the performance of the checkbox handling in the IFXBillingRecordList component. This is mostly done by removing the `nextTick()` calls that wrapped the actual checking for group indeterminate state and toggle checkboxes when the group checkbox was clicked.

I've also added a summary details button that shows/hides a list of charges by expense code in the header row. The headers are redrawn when filtering so this will remove the summary details but they can be gotten back by clicking the button again.

I've also added `organization` as a top-level attribute on the `BillingRecord` object so the user can search/filter on it.
