### PR TITLE
Fetch billing record for edit, fix rate display bug, missing msg

### DIFF
--- a/src/components/billingRecord/IFXBillingRecordDetail.vue
+++ b/src/components/billingRecord/IFXBillingRecordDetail.vue
@@ -325,7 +325,7 @@ export default {
               {{ item.charge | centsToDollars }}
             </template>
             <template v-slot:item.rate="{ item }">
-              {{ item.rate | centsToDollars }}
+              {{ item.rate }}
             </template>
           </v-data-table>
           <span v-else>None</span>

--- a/src/components/billingRecord/IFXBillingRecordList.vue
+++ b/src/components/billingRecord/IFXBillingRecordList.vue
@@ -178,7 +178,7 @@ export default {
       if (br.id) {
         // Go get it
         br = await this.apiRef.getByID(this.facility.invoicePrefix, br.id)
-        this.items[index] = br
+        this.$set(this.items, index, br)
         return br
       }
       console.log(`Billing record with id not found at item index ${index}`)

--- a/src/components/billingRecord/IFXBillingRecordList.vue
+++ b/src/components/billingRecord/IFXBillingRecordList.vue
@@ -169,6 +169,21 @@ export default {
       }
       return message
     },
+    async getFullBillingRecordByItemIndex(index) {
+      let br = this.items?.[index]
+      if (br?.billingRecordStates?.length) {
+        // Full record is already there
+        return br
+      }
+      if (br.id) {
+        // Go get it
+        br = await this.apiRef.getByID(this.facility.invoicePrefix, br.id)
+        this.items[index] = br
+        return br
+      }
+      console.log(`Billing record with id not found at item index ${index}`)
+      return null
+    },
     billingRecordsAreFinal(items) {
       // Returns true if any records in the list are in the FINAL state
       if (!items || !items.length) {
@@ -418,12 +433,13 @@ export default {
     closeTxnDialog() {
       this.txnDialog = false
     },
-    openTxnDialog(item) {
+    async openTxnDialog(item) {
       const index = this.items.findIndex((rec) => rec.id === item.id)
+      const br = await this.getFullBillingRecordByItemIndex(index)
       if (index !== -1) {
         this.editedItem = { ...this.defaultItem }
-        this.editedItem.rate = item.rate
-        this.editedItem.orgRec = item
+        this.editedItem.rate = br.rate
+        this.editedItem.orgRec = br
         this.editedItem.index = index
         this.editedItem.author = { ...this.$api.authUser }
         this.$nextTick(() => {
@@ -492,8 +508,9 @@ export default {
       this.editedRecord = {}
       this.editingIndex = null
     },
-    updateSpecificRecord(billingRec) {
-      const newBillingRec = cloneDeep(billingRec)
+    async updateSpecificRecord(billingRec) {
+      const index = this.items.findIndex((rec) => rec.id === billingRec.id)
+      const newBillingRec = await this.getFullBillingRecordByItemIndex(index)
       newBillingRec.account = this.newExpenseCode.data
       this.updateBillingRecord(newBillingRec, this.editingIndex)
       this.closeEditDialog()

--- a/src/components/billingRecord/IFXBillingRecordList.vue
+++ b/src/components/billingRecord/IFXBillingRecordList.vue
@@ -55,7 +55,6 @@ export default {
   },
   mounted() {
     this.facilityBillingRecords()
-      .then((response) => response.msg)
       .catch((error) => {
         const errorMessage = this.getErrorMessage(error)
         this.messageType = 'error'

--- a/src/components/billingRecord/IFXBillingRecordTransactions.vue
+++ b/src/components/billingRecord/IFXBillingRecordTransactions.vue
@@ -39,7 +39,7 @@ export default {
         {{ item.charge | centsToDollars }}
       </template>
       <template v-slot:item.rate="{ item }">
-        {{ item.rate | centsToDollars }}
+        {{ item.rate }}
       </template>
     </v-data-table>
   </td>


### PR DESCRIPTION
Fetch full billing record when attempting to edit or add transactions; due to get-billing-record-list, it won't initially be a full billing record
Rate is a string, so should not be converted to dollars 
msg is not a property of the billing record list response