### PR TITLE
Implement billing record review notification 

### DIFF
--- a/src/api/IFXAPI.js
+++ b/src/api/IFXAPI.js
@@ -832,6 +832,10 @@ export default class IFXAPIService {
       const url = `${this.urls.CALCULATE_BILLING_MONTH}${facility.invoicePrefix}/${year}/${month}/`
       return this.axios.post(url, { recalculate })
     }
+    api.billingRecordReviewNotification = (ifxorg_ids, test = []) => {
+      const url = `${this.urls.BILLING_RECORD_REVIEW_NOTIFICATION}`
+      return this.axios.post(url, { ifxorg_ids, test }, { headers: { 'Content-Type': 'application/json' } })
+    }
     api.getUsagesForFacility = (facility, year, month) => {
       if (facility.name === 'Liquid Nitrogen Service') {
         return this.nitrogenLog.getList(null, year, month)
@@ -895,6 +899,27 @@ export default class IFXAPIService {
         recipientField: recipientField,
       },
     })
+  }
+
+  async reviewLabManagerNotifications(organizationSlugs, selectedContactables,) {
+    let orgIFXIDs = []
+    let emails = []
+    if (selectedContactables.length) {
+      emails = selectedContactables.map(contact => contact.detail)
+    }
+    if (organizationSlugs.length) {
+      // There are no test email addresses so create the array of org ids
+      const orgs = await this.organization.getList()
+      orgIFXIDs = organizationSlugs.map(org => {
+        const fullOrg = orgs.find(anOrg => org === anOrg.slug)
+        if (fullOrg) {
+          return fullOrg.ifxOrg
+        }
+        return ''
+      })
+    }
+    const response = await this.billingRecord.billingRecordReviewNotification(orgIFXIDs, emails)
+    return response
   }
 
   updateAuthorizations(ifxids) {

--- a/src/api/IFXAPI.js
+++ b/src/api/IFXAPI.js
@@ -832,8 +832,8 @@ export default class IFXAPIService {
       const url = `${this.urls.CALCULATE_BILLING_MONTH}${facility.invoicePrefix}/${year}/${month}/`
       return this.axios.post(url, { recalculate })
     }
-    api.billingRecordReviewNotification = (ifxorg_ids, test = []) => {
-      const url = `${this.urls.BILLING_RECORD_REVIEW_NOTIFICATION}`
+    api.billingRecordReviewNotification = (ifxorg_ids, test = [], facility, year, month) => {
+      const url = `${this.urls.BILLING_RECORD_REVIEW_NOTIFICATION}${facility.invoicePrefix}/${year}/${month}/`
       return this.axios.post(url, { ifxorg_ids, test }, { headers: { 'Content-Type': 'application/json' } })
     }
     api.getUsagesForFacility = (facility, year, month) => {
@@ -901,7 +901,7 @@ export default class IFXAPIService {
     })
   }
 
-  async reviewLabManagerNotifications(organizationSlugs, selectedContactables,) {
+  async reviewLabManagerNotifications(organizationSlugs, selectedContactables, facility, year, month) {
     let orgIFXIDs = []
     let emails = []
     if (selectedContactables.length) {
@@ -918,7 +918,7 @@ export default class IFXAPIService {
         return ''
       })
     }
-    const response = await this.billingRecord.billingRecordReviewNotification(orgIFXIDs, emails)
+    const response = await this.billingRecord.billingRecordReviewNotification(orgIFXIDs, emails, facility, year, month)
     return response
   }
 

--- a/src/components/billingRecord/IFXBillingRecordList.vue
+++ b/src/components/billingRecord/IFXBillingRecordList.vue
@@ -544,14 +544,20 @@ export default {
       this.sendingNotifications = true
       const orgs = this.selected.length ? this.selected : this.filteredItems
       const orgSlugs = orgs.map((item) => item.account.organization)
-      const response = await this.$api.reviewLabManagerNotifications(
-        [...new Set(orgSlugs)],
-        this.selectedContactables,
-        this.facility,
-        this.year,
-        this.month
-      )
-      this.emailResponse = response.data
+      try {
+        const response = await this.$api.reviewLabManagerNotifications(
+          [...new Set(orgSlugs)],
+          this.selectedContactables,
+          this.facility,
+          this.year,
+          this.month
+        )
+        this.emailResponse = response.data
+      } catch (error) {
+        this.emailResponse = null
+        const message = this.getErrorMessage(error)
+        this.showMessage(message)
+      }
       this.sendingNotifications = false
     },
     getSelectedOrgs() {
@@ -568,6 +574,9 @@ export default {
           this.contactables = result
         })
       }
+      // Clear any previous usage
+      this.selectedContactables = []
+      this.emailResponse = null
       this.notifyDialog = true
     },
   },

--- a/src/components/billingRecord/IFXBillingRecordList.vue
+++ b/src/components/billingRecord/IFXBillingRecordList.vue
@@ -16,7 +16,7 @@ export default {
     IFXSearchField,
     IFXBillingRecordTransactions,
     IFXContactablesCombobox,
-    IFXMailButton
+    IFXMailButton,
   },
   mixins: [IFXBillingRecordMixin],
   filters: {
@@ -575,7 +575,7 @@ export default {
         })
       }
       // Clear any previous usage
-      this.selectedContactables = []
+      this.selectedContactables.splice(0)
       this.emailResponse = null
       this.notifyDialog = true
     },
@@ -681,7 +681,8 @@ export default {
                                   </div>
                                   <v-row no-gutters v-if="emailResponse">
                                     <v-col cols="12" class="text-body-1">
-                                      <div v-if="emailResponse.errors">
+                                      <div class="text-body-1 font-weight-medium text-center">Email Notification Results</div>
+                                      <div v-if="Object.keys(emailResponse.errors).length">
                                         The following
                                         <span class="red--text">errors</span>
                                         occurred trying to send emails:
@@ -697,18 +698,18 @@ export default {
                                         </ul>
                                       </div>
                                       <div v-if="emailResponse.successes.length" class="mt-2">
-                                        Sent to the following recipients:
+                                        Successfully <span class="green--text">sent</span> for the following organizations:
                                         <ul class="lab-manager-list">
                                           <li v-for="value in emailResponse.successes" :key="value">
-                                            <div>{{ value }}</div>
+                                            <span>{{ value }}</span>
                                           </li>
                                         </ul>
                                       </div>
                                       <div v-if="emailResponse.nobrs.length" class="mt-2">
-                                        The following organizations had no billing records:
+                                        The following <span class="yellow--text text--darken-3">organizations</span> had no billing records:
                                         <ul class="lab-manager-list">
                                           <li v-for="value in emailResponse.nobrs" :key="value">
-                                            <div>{{ value }}</div>
+                                            <span>{{ value }}</span>
                                           </li>
                                         </ul>
                                       </div>

--- a/src/components/billingRecord/IFXBillingRecordList.vue
+++ b/src/components/billingRecord/IFXBillingRecordList.vue
@@ -680,7 +680,7 @@ export default {
                                     <v-progress-linear indeterminate></v-progress-linear>
                                   </div>
                                   <v-row no-gutters v-if="emailResponse">
-                                    <v-col cols="12" class="text-body-1">
+                                    <v-col cols="12" class="text-body-1 results-section">
                                       <div class="text-body-1 font-weight-medium text-center">Email Notification Results</div>
                                       <div v-if="Object.keys(emailResponse.errors).length">
                                         The following
@@ -1069,6 +1069,10 @@ export default {
 }
 .list-style-none {
   list-style-type: none;
+}
+.results-section {
+  max-height: 30rem;
+  overflow: auto;
 }
 </style>
 <style>

--- a/src/components/billingRecord/IFXBillingRecordList.vue
+++ b/src/components/billingRecord/IFXBillingRecordList.vue
@@ -579,6 +579,15 @@ export default {
       this.emailResponse = null
       this.notifyDialog = true
     },
+    buildNotificationlList() {
+      let list = ''
+      if (this.selectedContactables.length) {
+        list = this.selectedContactables.map((contact) => contact.name).join(', ')
+      } else {
+        list = 'Lab managers'
+      }
+      return list
+    },
   },
   watch: {
     filteredItems() {
@@ -635,23 +644,10 @@ export default {
                               <v-card-title>
                                 <span class="text-h5">Notify Lab Managers</span>
                               </v-card-title>
-                              <!-- <v-card-subtitle>
-                                Send email to the lab managers of all selected organizations
-                              </v-card-subtitle> -->
                               <v-card-text>
                                 <v-form v-model="isValid">
                                   <v-row class="text-body-1">
                                     <v-col v-if="selected.length">
-                                      <!-- <v-list dense>
-                                        <v-subheader>Send to the managers for the following labs:</v-subheader>
-                                        <v-list-item v-for="org in getSelectedOrgs()" :key="org">
-                                          <v-list-item-content>
-                                            <v-list-item-title>
-                                              {{ $api.organization.parseSlug(org).name }}
-                                            </v-list-item-title>
-                                          </v-list-item-content>
-                                        </v-list-item>
-                                      </v-list> -->
                                       <div class="mb-2">Send to the managers for the following labs:</div>
                                       <ul class="lab-manager-list">
                                         <li v-for="org in getSelectedOrgs()" :key="org" class="font-weight-medium">
@@ -681,8 +677,23 @@ export default {
                                   </div>
                                   <v-row no-gutters v-if="emailResponse">
                                     <v-col cols="12" class="text-body-1 results-section">
-                                      <div class="text-body-1 font-weight-medium text-center">Email Notification Results</div>
-                                      <div v-if="Object.keys(emailResponse.errors).length">
+                                      <div class="text-body-1 font-weight-medium text-center">
+                                        Email Notification Results
+                                      </div>
+                                      <div class="text-body-2 font-weight-regular text-center">
+                                        Sent to {{ buildNotificationlList() }}
+                                      </div>
+                                      <div v-if="emailResponse.successes.length" class="my-3 pb-2 border-bottom">
+                                        Successfully
+                                        <span class="green--text">sent</span>
+                                        for the following organizations:
+                                        <ul class="lab-manager-list">
+                                          <li v-for="value in emailResponse.successes" :key="value">
+                                            <span>{{ value }}</span>
+                                          </li>
+                                        </ul>
+                                      </div>
+                                      <div v-if="Object.keys(emailResponse.errors).length" class="my-3 pb-2 border-bottom">
                                         The following
                                         <span class="red--text">errors</span>
                                         occurred trying to send emails:
@@ -697,16 +708,10 @@ export default {
                                           </li>
                                         </ul>
                                       </div>
-                                      <div v-if="emailResponse.successes.length" class="mt-2">
-                                        Successfully <span class="green--text">sent</span> for the following organizations:
-                                        <ul class="lab-manager-list">
-                                          <li v-for="value in emailResponse.successes" :key="value">
-                                            <span>{{ value }}</span>
-                                          </li>
-                                        </ul>
-                                      </div>
-                                      <div v-if="emailResponse.nobrs.length" class="mt-2">
-                                        The following <span class="yellow--text text--darken-3">organizations</span> had no billing records:
+                                      <div v-if="emailResponse.nobrs.length" class="my-3 pb-2 border-bottom">
+                                        The following organizations had&nbsp;
+                                        <span class="yellow--text text--darken-3">no billing records</span>
+                                        :
                                         <ul class="lab-manager-list">
                                           <li v-for="value in emailResponse.nobrs" :key="value">
                                             <span>{{ value }}</span>
@@ -1073,6 +1078,9 @@ export default {
 .results-section {
   max-height: 30rem;
   overflow: auto;
+}
+.border-bottom {
+  border-bottom: 1px solid #ccc;
 }
 </style>
 <style>


### PR DESCRIPTION
This PR optionally (via a prop that defaults to `false`) replaces the "mail button" in the `IFXBillingRecordList` component with a similar button that opens a dialog showing the selected organizations as well as a `contactable` dropdown. The user can either send to the contacts for the selected labs or select contacts to "preview" the emails that would be sent. If any contacts are selected, no lab managers are contacted.

The results of the email sending are then displayed; this includes `errors`, `successes` and a list of organizations for which there are no Billing Records. Any errors show the organization and the specific errors for each.