### PR TITLE
Decimal charge handling

### DIFF
--- a/src/components/billingRecord/IFXBillingRecord.js
+++ b/src/components/billingRecord/IFXBillingRecord.js
@@ -14,6 +14,14 @@ export class BillingTransaction extends IFXItemBase {
     this.data.charge = charge
   }
 
+  get decimalCharge() {
+    return this.data.decimal_charge
+  }
+
+  set decimalCharge(decimalCharge) {
+    this.data.decimal_charge = decimalCharge
+  }
+
   get rate() {
     return this.data.rate
   }
@@ -82,6 +90,14 @@ export default class BillingRecord extends IFXItemBase {
 
   set charge(charge) {
     this.data.charge = charge
+  }
+
+  get decimalCharge() {
+    return this.data.decimal_charge
+  }
+
+  set decimalCharge(decimalCharge) {
+    this.data.decimal_charge = decimalCharge
   }
 
   get description() {

--- a/src/components/billingRecord/IFXBillingRecordHeaderDecimal.vue
+++ b/src/components/billingRecord/IFXBillingRecordHeaderDecimal.vue
@@ -1,0 +1,113 @@
+<script>
+export default {
+  name: 'IFXBillingRecordHeaderDecimal',
+  props: {
+    group: {
+      type: String,
+      required: true,
+    },
+    colSpan: {
+      type: Number,
+      required: true,
+    },
+    isOpen: {
+      type: Boolean,
+      required: true,
+    },
+    showCheckboxes: {
+      type: Boolean,
+      required: true,
+    },
+    toggle: {
+      type: Function,
+      required: true,
+    },
+    toggleGroup: {
+      type: Function,
+      required: true,
+    },
+    rowSelectionToggle: {
+      type: Array,
+      required: false,
+    },
+    rowSelectionToggleIndeterminateGroup: {
+      type: Boolean,
+      required: false,
+    },
+    summaryCharges: {
+      type: Number,
+      required: true,
+    },
+    getSummaryDetails: {
+      type: Function,
+      required: true,
+    },
+  },
+  mounted() {
+    this.localRowSelectionToggle = this.rowSelectionToggle.concat()
+  },
+  data() {
+    return {
+      localRowSelectionToggle: [],
+      showSummaryDetail: false,
+      summaryButtonText: 'Show',
+      summaryDetails: []
+    }
+  },
+  computed: {},
+  methods: {
+    syncData() {
+      this.$emit('update:row-selection-toggle', this.localRowSelectionToggle)
+      this.$emit('update:row-selection-toggle-indeterminate', this.rowSelectionToggleIndeterminateGroup)
+      this.toggleGroup(this.group)
+    },
+    toggleSummaryDetail() {
+      this.summaryButtonText = this.showSummaryDetail ? 'Show' : 'Hide'
+      if (!this.showSummaryDetail && this.summaryDetails.length === 0) {
+        this.summaryDetails = Array.from(this.getSummaryDetails(this.group).entries())
+      }
+      this.showSummaryDetail = !this.showSummaryDetail
+    },
+  },
+  watch: {},
+}
+</script>
+<template>
+  <td :colspan="colSpan" class="py-2">
+    <v-row>
+      <v-checkbox
+        v-if="showCheckboxes"
+        v-model="localRowSelectionToggle"
+        :value="group"
+        hide-details
+        multiple
+        :indeterminate.sync="rowSelectionToggleIndeterminateGroup"
+        class="shrink ml-3 mt-0"
+        @change="syncData()"
+      ></v-checkbox>
+      <div>
+        <v-btn icon small @click="toggle">
+          <v-icon :class="{'active' : isOpen}">mdi-menu-right</v-icon>
+        </v-btn>
+        <span class="group-header">
+          {{ $api.organization.parseSlug(group).name }}
+        </span>
+        <span class="ml-3 font-weight-medium">Total charges: {{ summaryCharges | dollars }}</span>
+        <v-btn small text @click="toggleSummaryDetail" class="ml-2">{{summaryButtonText}} Acct Summary</v-btn>
+      </div>
+    </v-row>
+    <v-row v-if="showSummaryDetail">
+      <v-col class="py-1 ml-9">
+        <v-row v-for="entry in summaryDetails" :key="`${group}-${entry[0]}`" class="text-body-2">
+          <v-col cols="5" class="ml-3">{{entry[0]}}</v-col><v-col class="text-xs-left ml-3 font-weight-medium">{{ entry[1] | dollars}} </v-col>
+        </v-row>
+      </v-col>
+    </v-row>
+  </td>
+</template>
+<style scoped lang="scss">
+.active {
+  -webkit-transform: rotate(90deg);
+  transform: rotate(90deg);
+}
+</style>

--- a/src/components/billingRecord/IFXBillingRecordList.vue
+++ b/src/components/billingRecord/IFXBillingRecordList.vue
@@ -133,6 +133,7 @@ export default {
       contactables: [],
       sendingNotifications: false,
       emailResponse: null,
+      newExpenseCode: null,
     }
   },
   computed: {
@@ -257,7 +258,7 @@ export default {
           const keys = header.value.split('.')
           // Formatted key for displayed that data in final file
           const formattedKey = header.text
-          let value = this.items[i]
+          let value = this.filteredItems[i]
           keys.forEach((key) => {
             value = value[key]
           })
@@ -548,7 +549,7 @@ export default {
 
         this.editingIndex = index
         this.editedRecord = cloneDeep(item)
-        this.newExpenseCode = this.$api.account.create(item.account)
+        this.newExpenseCode = await this.$api.account.create(item.account)
 
         this.editDialog = true
       }
@@ -1032,7 +1033,6 @@ export default {
                         v-model="newExpenseCode"
                         :items="expenseCodes"
                         item-text="slug"
-                        item-value="slug"
                         label="Expense Code / PO"
                         :error-messages="errors[newExpenseCode]"
                         :rules="formRules.generic"

--- a/src/components/billingRecord/IFXBillingRecordList.vue
+++ b/src/components/billingRecord/IFXBillingRecordList.vue
@@ -111,7 +111,6 @@ export default {
       editedItem: {
         rate: 0,
         charge: 0,
-        decimalCharge: 0,
         description: null,
         author: {},
         orgRec: {},
@@ -120,7 +119,6 @@ export default {
       defaultItem: {
         rate: 0,
         charge: 0,
-        decimalCharge: 0,
         description: '',
         author: {},
       },
@@ -499,10 +497,9 @@ export default {
     },
     addNewTransaction(item) {
       const orgBillingRec = item.orgRec
-      const { charge, decimalCharge, rate, description, author } = item
+      const { charge, rate, description, author } = item
       const newTransactionData = {
         charge,
-        decimalCharge,
         rate,
         description,
         author,

--- a/src/components/billingRecord/IFXBillingRecordListDecimal.vue
+++ b/src/components/billingRecord/IFXBillingRecordListDecimal.vue
@@ -133,6 +133,7 @@ export default {
       contactables: [],
       sendingNotifications: false,
       emailResponse: null,
+      newExpenseCode: null,
     }
   },
   computed: {
@@ -257,7 +258,7 @@ export default {
           const keys = header.value.split('.')
           // Formatted key for displayed that data in final file
           const formattedKey = header.text
-          let value = this.items[i]
+          let value = this.filteredItems[i]
           keys.forEach((key) => {
             value = value[key]
           })
@@ -548,7 +549,7 @@ export default {
 
         this.editingIndex = index
         this.editedRecord = cloneDeep(item)
-        this.newExpenseCode = this.$api.account.create(item.account)
+        this.newExpenseCode = await this.$api.account.create(item.account)
 
         this.editDialog = true
       }
@@ -1032,7 +1033,6 @@ export default {
                         v-model="newExpenseCode"
                         :items="expenseCodes"
                         item-text="slug"
-                        item-value="slug"
                         label="Expense Code / PO"
                         :error-messages="errors[newExpenseCode]"
                         :rules="formRules.generic"

--- a/src/components/billingRecord/IFXBillingRecordListDecimal.vue
+++ b/src/components/billingRecord/IFXBillingRecordListDecimal.vue
@@ -6,19 +6,19 @@ import IFXBillingRecordMixin from '@/components/billingRecord/IFXBillingRecordMi
 import IFXButton from '@/components/IFXButton'
 import IFXSearchField from '@/components/IFXSearchField'
 import IFXMailButton from '@/components/mailing/IFXMailButton'
-import IFXBillingRecordHeader from '@/components/billingRecord/IFXBillingRecordHeader'
+import IFXBillingRecordHeaderDecimal from '@/components/billingRecord/IFXBillingRecordHeaderDecimal'
 import IFXContactablesCombobox from '@/components/IFXContactablesCombobox'
-import IFXBillingRecordTransactions from './IFXBillingRecordTransactions'
+import IFXBillingRecordTransactionsDecimal from './IFXBillingRecordTransactionsDecimal'
 
 export default {
-  name: 'IFXBillingRecordList',
+  name: 'IFXBillingRecordListDecimal',
   components: {
     IFXButton,
     IFXSearchField,
-    IFXBillingRecordTransactions,
+    IFXBillingRecordTransactionsDecimal,
     IFXContactablesCombobox,
     IFXMailButton,
-    IFXBillingRecordHeader
+    IFXBillingRecordHeaderDecimal
   },
   mixins: [IFXBillingRecordMixin],
   filters: {
@@ -92,7 +92,7 @@ export default {
         { text: 'Lab', value: 'account.organization', sortable: true },
         { text: 'Expense Code / PO', value: 'account.slug', sortable: true },
         { text: 'Product', value: 'product', sortable: true },
-        { text: 'Charge', value: 'charge', sortable: true, width: '100px' },
+        { text: 'Charge', value: 'decimalCharge', sortable: true, width: '100px' },
         { text: 'Percent', value: 'percent', sortable: true, width: '100px' },
         { text: 'Usage id', value: 'productUsage.id', sortable: true },
         { text: 'Txn desc', value: 'transactions', sortable: false },
@@ -406,14 +406,14 @@ export default {
     },
     summaryCharges(group) {
       const records = this.filteredItems.filter((item) => item.account.organization === group)
-      const summary = records.reduce((prev, current) => prev + current.charge, 0)
+      const summary = records.reduce((prev, current) => prev + current.decimalCharge, 0)
       return summary
     },
     getSummaryDetails(group) {
       const records = this.filteredItems.filter((item) => item.account.organization === group)
       const expenseMap = new Map()
       records.forEach((item) => {
-        const charge = item.charge
+        const charge = item.decimalCharge
         if (expenseMap.has(item.account.slug)) {
           const value = expenseMap.get(item.account.slug)
           expenseMap.set(item.account.slug, value + charge)
@@ -906,7 +906,7 @@ export default {
               v-slot:group.header="{ group, headers, isOpen, toggle }"
               v-on:rendered="itemRendered('group.header')"
             >
-                <IFXBillingRecordHeader
+                <IFXBillingRecordHeaderDecimal
                 :key="group"
                 :item="item"
                 :group="group"
@@ -945,8 +945,8 @@ export default {
                 </v-row>
               </div>
             </template>
-            <template v-slot:item.charge="{ item }">
-              {{ item.charge | centsToDollars }}
+            <template v-slot:item.decimalCharge="{ item }">
+              {{ item.decimalCharge | dollars }}
             </template>
             <template v-slot:item.actions="{ item }">
               <div class="d-flex flex-row">
@@ -968,7 +968,7 @@ export default {
               </div>
             </template>
             <template v-slot:expanded-item="{ item }">
-              <IFXBillingRecordTransactions :billingRecord="item" />
+              <IFXBillingRecordTransactionsDecimal :billingRecord="item" />
             </template>
             </v-data-table>
           <v-dialog v-model="txnDialog" max-width="600px">

--- a/src/components/billingRecord/IFXBillingRecordTransactions.vue
+++ b/src/components/billingRecord/IFXBillingRecordTransactions.vue
@@ -7,11 +7,6 @@ export default {
       type: Object,
       required: true,
     },
-    useDecimalCharge: {
-      type: Boolean,
-      required: false,
-      default: false,
-    }
   },
   mounted() {},
   data() {
@@ -41,8 +36,7 @@ export default {
       dense
     >
       <template v-slot:item.charge="{ item }">
-        <span v-if="useDecimalCharge">{{ item.decimalCharge }}</span>
-        <span v-else>{{ item.charge | centsToDollars }}</span>
+        {{ item.charge | centsToDollars }}
       </template>
       <template v-slot:item.rate="{ item }">
         {{ item.rate }}

--- a/src/components/billingRecord/IFXBillingRecordTransactionsDecimal.vue
+++ b/src/components/billingRecord/IFXBillingRecordTransactionsDecimal.vue
@@ -1,24 +1,19 @@
 <script>
 export default {
-  name: 'IFXBillingRecordTransactions',
+  name: 'IFXBillingRecordTransactionsDecimal',
   components: {},
   props: {
     billingRecord: {
       type: Object,
       required: true,
     },
-    useDecimalCharge: {
-      type: Boolean,
-      required: false,
-      default: false,
-    }
   },
   mounted() {},
   data() {
     return {
       txnHeaders: [
         { text: 'ID', value: 'id', sortable: true, hide: true },
-        { text: 'Charge', value: 'charge', sortable: true, width: '100px', namedSlot: true },
+        { text: 'Charge', value: 'decimalCharge', sortable: true, width: '100px', namedSlot: true },
         { text: 'Rate', value: 'rate', sortable: true },
         { text: 'User', value: 'author.full_name', sortable: true },
         { text: 'Description', value: 'description', sortable: true },
@@ -40,9 +35,8 @@ export default {
       hide-default-footer
       dense
     >
-      <template v-slot:item.charge="{ item }">
-        <span v-if="useDecimalCharge">{{ item.decimalCharge }}</span>
-        <span v-else>{{ item.charge | centsToDollars }}</span>
+      <template v-slot:item.decimalCharge="{ item }">
+        {{ item.decimalCharge | dollars }}
       </template>
       <template v-slot:item.rate="{ item }">
         {{ item.rate }}

--- a/src/components/billingRecord/IFXBillingRecords.vue
+++ b/src/components/billingRecord/IFXBillingRecords.vue
@@ -67,6 +67,9 @@ export default {
     async getFacilities() {
       this.facilities = await this.$api.facility.getList({ application_username: this.$api.vars.appName })
     },
+    isDecimalFacility(facility) {
+      return ['Research Computing Storage'].includes(facility.name)
+    },
     resetShowBillingRecords() {
       this.showBillingRecords = false
       this.keyModifier += 100
@@ -128,7 +131,18 @@ export default {
     <v-container v-if="showBillingRecords">
       <v-row v-for="facility in facilities" :key="facility.id + keyModifier">
         <v-col>
+          <IFXBillingRecordListDecimal
+            v-if="isDecimalFacility(facility)"
+            :facility="facility"
+            :date="date"
+            :organization="organization"
+            :allowInvoiceGeneration="false"
+            :allowApprovals="false"
+            :allowDownloads="false"
+            :useDefaultMailButton="useDefaultMailButton"
+          />
           <IFXBillingRecordList
+            v-else
             :facility="facility"
             :date="date"
             :organization="organization"

--- a/src/entrypoint.js
+++ b/src/entrypoint.js
@@ -98,6 +98,7 @@ import IFXProductMixin from '@/components/product/IFXProductMixin'
 
 // Billing
 import IFXBillingRecordList from '@/components/billingRecord/IFXBillingRecordList'
+import IFXBillingRecordListDecimal from '@/components/billingRecord/IFXBillingRecordListDecimal'
 import IFXBillingRecords from '@/components/billingRecord/IFXBillingRecords'
 import IFXBillingRecordDetail from '@/components/billingRecord/IFXBillingRecordDetail'
 import IFXCalculateBillingMonth from '@/components/billingRecord/IFXCalculateBillingMonth'
@@ -186,6 +187,7 @@ export {
   IFXProductCreateEdit,
   IFXPageActionBar,
   IFXBillingRecordList,
+  IFXBillingRecordListDecimal,
   IFXBillingRecords,
   IFXBillingRecordDetail,
   IFXCalculateBillingMonth,

--- a/src/filters/IFXFilters.js
+++ b/src/filters/IFXFilters.js
@@ -24,6 +24,16 @@ export function centsToDollars(cents) {
 }
 
 /**
+ * Display decimal as docllars
+ * @param {number} dollars
+ * @returns {number} value in dollars
+ */
+export function dollars(val) {
+  const formatter = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' })
+  return formatter.format(val)
+}
+
+/**
  * Capitalizes the first letter
  * @param {any} rawValue
  * @returns {string} a converted string
@@ -125,6 +135,7 @@ export function orgNameFromSlug(slug) {
 export default {
   humanDatetime,
   centsToDollars,
+  dollars,
   capitalizeFirstLetter,
   emailDisplay,
   stateDisplay,


### PR DESCRIPTION
- Adds support for decimal_charge handling by creating decimal_charge specific versions of IFXBillingRecordList, IFXBillingRecordTransactions and IFXBillingRecordHeader.  The proper IFXBillingRecordList variant is selected on a per-facility basis- currently just 'Research Computing Storage'
- Adds decimal_charge to BillingRecord and BillingTransaction
- Adds "dollar" filter that does not translation from pennies

