### PR TITLE
Fix default "notify lab managers" handler

### DIFF
--- a/src/components/billingRecord/IFXBillingRecordList.vue
+++ b/src/components/billingRecord/IFXBillingRecordList.vue
@@ -576,6 +576,17 @@ export default {
     allowEditingRecords(item) {
       return this.$api.auth.can('edit-records', this.$api.authUser) && item.currentState !== 'FINAL'
     },
+    defaultNotifyLabManagers() {
+      const orgSlugs = this.items.map((item) => item.account.organization)
+      this.$api.notifyLabManagers(
+        [...new Set(orgSlugs)],
+        this.facility,
+        this.year,
+        this.month,
+        this.recipientField,
+        this.$router
+      )
+    },
     async notifyLabManagers() {
       this.emailResponse = null
       this.sendingNotifications = true
@@ -667,7 +678,7 @@ export default {
                       v-model="recipientField"
                       :disabled="!filteredItems.length"
                       toolTip="Notify Lab Managers"
-                      @input="notifyLabManagers()"
+                      @input="defaultNotifyLabManagers()"
                     ></IFXMailButton>
                     <v-tooltip top v-else>
                       <template v-slot:activator="{ on, attrs }">

--- a/src/components/billingRecord/IFXBillingRecordListDecimal.vue
+++ b/src/components/billingRecord/IFXBillingRecordListDecimal.vue
@@ -579,6 +579,17 @@ export default {
     allowEditingRecords(item) {
       return this.$api.auth.can('edit-records', this.$api.authUser) && item.currentState !== 'FINAL'
     },
+    defaultNotifyLabManagers() {
+      const orgSlugs = this.items.map((item) => item.account.organization)
+      this.$api.notifyLabManagers(
+        [...new Set(orgSlugs)],
+        this.facility,
+        this.year,
+        this.month,
+        this.recipientField,
+        this.$router
+      )
+    },
     async notifyLabManagers() {
       this.emailResponse = null
       this.sendingNotifications = true
@@ -670,7 +681,7 @@ export default {
                       v-model="recipientField"
                       :disabled="!filteredItems.length"
                       toolTip="Notify Lab Managers"
-                      @input="notifyLabManagers()"
+                      @input="defaultNotifyLabManagers()"
                     ></IFXMailButton>
                     <v-tooltip top v-else>
                       <template v-slot:activator="{ on, attrs }">

--- a/src/components/mailing/IFXMailingCompose.vue
+++ b/src/components/mailing/IFXMailingCompose.vue
@@ -189,7 +189,7 @@ export default {
                 me.toList = result2
               }
               this.isLoading = false
-              if (orgContactNotFound) {
+              if (orgContactNotFound.length) {
                 const names = orgContactNotFound.join(', ')
                 const message = `Unable to find lab manager contact for ${names}`
                 me.showMessage(message)


### PR DESCRIPTION
This PR fixes handling the default "notify lab managers" button"; this is the one that shows To/CC/BCC buttons and then routes to the `Compose Mailing` page with the Lab Manager auto-filled in. A preview [PR](https://github.com/harvardinformatics/ifxvue/pull/99)) changed that method to handle the new button that allows for sending test emails. But since the old button is still the default, the old method should still be present.

Also, fix a small bug when the lab managers were being fetched, a snackbar message would show up even if all the lab managers were found.