### PR TITLE
Use POST for `get_contactables`

### DIFF
--- a/src/api/IFXAPI.js
+++ b/src/api/IFXAPI.js
@@ -540,7 +540,7 @@ export default class IFXAPIService {
           params.org_slugs = params.org_slugs.join(',')
         }
         const contactables = await this.axios
-          .get(url, { params })
+          .post(url, { params })
           .then((response) => response.data)
           .catch((error) => {
             throw new Error(error)

--- a/src/api/IFXAPI.js
+++ b/src/api/IFXAPI.js
@@ -540,7 +540,7 @@ export default class IFXAPIService {
           params.org_slugs = params.org_slugs.join(',')
         }
         const contactables = await this.axios
-          .post(url, { params })
+          .post(url, params)
           .then((response) => response.data)
           .catch((error) => {
             throw new Error(error)


### PR DESCRIPTION
This PR changes how get_contactable receives its data. We used to use GET but the list of orgs could exceed the max length of a URL so this has been changed to use POST. Goes with `IFXUser` PR https://github.com/harvardinformatics/ifxuser/pull/19