### PR TITLE
Account list

### DIFF
--- a/src/components/billingRecord/IFXBillingRecordList.vue
+++ b/src/components/billingRecord/IFXBillingRecordList.vue
@@ -535,14 +535,7 @@ export default {
     async openEditDialog(item) {
       const index = this.items.findIndex((rec) => rec.id === item.id)
       if (index !== -1) {
-        if (this.$api.auth.can('set-any-account', this.$api.authUser)) {
-          this.expenseCodes = await this.$api.account.getList()
-        } else {
-          const currentUserRecord = await this.$api.auth
-            .getCurrentUserRecord()
-            .catch(() => this.showMessage('Could not get user record. '))
-          this.expenseCodes = currentUserRecord.accounts
-        }
+        this.expenseCodes = await this.$api.account.getList()
 
         this.editingIndex = index
         this.editedRecord = cloneDeep(item)

--- a/src/components/billingRecord/IFXBillingRecordList.vue
+++ b/src/components/billingRecord/IFXBillingRecordList.vue
@@ -536,6 +536,7 @@ export default {
       const index = this.items.findIndex((rec) => rec.id === item.id)
       if (index !== -1) {
         this.expenseCodes = await this.$api.account.getList()
+        console.log('got codes ', this.expenseCodes)
 
         this.editingIndex = index
         this.editedRecord = cloneDeep(item)

--- a/src/components/billingRecord/IFXBillingRecordListDecimal.vue
+++ b/src/components/billingRecord/IFXBillingRecordListDecimal.vue
@@ -538,15 +538,7 @@ export default {
     async openEditDialog(item) {
       const index = this.items.findIndex((rec) => rec.id === item.id)
       if (index !== -1) {
-        if (this.$api.auth.can('set-any-account', this.$api.authUser)) {
-          this.expenseCodes = await this.$api.account.getList()
-        } else {
-          const currentUserRecord = await this.$api.auth
-            .getCurrentUserRecord()
-            .catch(() => this.showMessage('Could not get user record. '))
-          this.expenseCodes = currentUserRecord.accounts
-        }
-
+        this.expenseCodes = await this.$api.account.getList()
         this.editingIndex = index
         this.editedRecord = cloneDeep(item)
         this.newExpenseCode = await this.$api.account.create(item.account)


### PR DESCRIPTION
Let the backend determine the list of accounts that can be seen when editing a billing record.  Admins will see all, lab managers will see those with their roots or assigned accounts.