### PR TITLE
This *really* needs to be a fixed height to make the scrollTo work

### DIFF
--- a/src/components/calendar/IFXCalendarList.vue
+++ b/src/components/calendar/IFXCalendarList.vue
@@ -996,7 +996,7 @@ export default {
             </v-menu>
           </v-toolbar>
         </v-sheet>
-        <v-sheet :min-height="calHeight" class="d-flex justify-middle relative">
+        <v-sheet :height="calHeight" class="d-flex justify-middle relative">
           <span class="flex-grow-1">
             <v-calendar
               ref="calendar"


### PR DESCRIPTION
This PR fixes the height of the calendar pane so the `scrollTo` function will work.