### PR TITLE
Don’t wrap the facility name

### DIFF
--- a/src/components/billingRecord/IFXBillingRecordList.vue
+++ b/src/components/billingRecord/IFXBillingRecordList.vue
@@ -648,7 +648,7 @@ export default {
       <v-card-title>
         <v-row class="d-flex justify-space-between">
           <v-col cols="4">
-            <div>
+            <div class="text-no-wrap">
               {{ facility.name }}
             </div>
           </v-col>

--- a/src/components/billingRecord/IFXBillingRecordListDecimal.vue
+++ b/src/components/billingRecord/IFXBillingRecordListDecimal.vue
@@ -649,7 +649,7 @@ export default {
       <v-card-title>
         <v-row class="d-flex justify-space-between">
           <v-col cols="4">
-            <div>
+            <div class="text-no-wrap">
               {{ facility.name }}
             </div>
           </v-col>


### PR DESCRIPTION
For CBSN, the name wraps, which looks odd. So set `no-wrap`