### PR TITLE
Fix overflow in billing records row

### DIFF
--- a/src/components/billingRecord/IFXBillingRecordList.vue
+++ b/src/components/billingRecord/IFXBillingRecordList.vue
@@ -943,9 +943,9 @@ export default {
             </template>
             <template v-slot:item.transactions="{ item }">
               <div style="min-width: 150px;">
-                <v-row v-for="txn in item.transactions" :key="txn.id">
-                  <v-col>{{ txn | transactionDisplay }}</v-col>
-                </v-row>
+                <div class="mb-1" v-for="txn in item.transactions" :key="txn.id">
+                  {{ txn | transactionDisplay }}
+                </div>
               </div>
             </template>
             <template v-slot:item.charge="{ item }">

--- a/src/components/billingRecord/IFXBillingRecordList.vue
+++ b/src/components/billingRecord/IFXBillingRecordList.vue
@@ -943,7 +943,7 @@ export default {
             </template>
             <template v-slot:item.transactions="{ item }">
               <div style="min-width: 150px;">
-                <div class="mb-1" v-for="txn in item.transactions" :key="txn.id">
+                <div class="my-1" v-for="txn in item.transactions" :key="txn.id">
                   {{ txn | transactionDisplay }}
                 </div>
               </div>

--- a/src/components/billingRecord/IFXBillingRecordList.vue
+++ b/src/components/billingRecord/IFXBillingRecordList.vue
@@ -942,9 +942,9 @@ export default {
               ({{ item.account.name }})
             </template>
             <template v-slot:item.transactions="{ item }">
-              <div style="min-width: 150px">
+              <div style="min-width: 150px;">
                 <v-row v-for="txn in item.transactions" :key="txn.id">
-                  {{ txn | transactionDisplay }}
+                  <v-col>{{ txn | transactionDisplay }}</v-col>
                 </v-row>
               </div>
             </template>

--- a/src/components/billingRecord/IFXBillingRecordListDecimal.vue
+++ b/src/components/billingRecord/IFXBillingRecordListDecimal.vue
@@ -944,9 +944,9 @@ export default {
             </template>
             <template v-slot:item.transactions="{ item }">
               <div style="min-width: 150px">
-                <v-row v-for="txn in item.transactions" :key="txn.id">
+                <div class="my-1" v-for="txn in item.transactions" :key="txn.id">
                   {{ txn | transactionDisplay }}
-                </v-row>
+                </div>
               </div>
             </template>
             <template v-slot:item.decimalCharge="{ item }">

--- a/src/components/page/IFXPageHeader.vue
+++ b/src/components/page/IFXPageHeader.vue
@@ -74,7 +74,7 @@ export default {
           </div>
         </v-col>
       </v-row>
-      <v-row v-if="hasTitle" justify="space-between" align="center">
+      <v-row v-if="hasTitle" justify="space-between" align="center" class="my-0">
         <div class="title-ctr">
           <h1 data-cy="header-title" :class="headerClass"><slot name="title"></slot></h1>
           <h1 data-cy="header-id" :class="headerClass"><slot name="id"></slot></h1>


### PR DESCRIPTION
The transaction info in the billing record row was overflowing the row container, most likely due to the upgrade from Vuetify 2.3.x to 2.6.x. This PR fixes that by removing the `<v-row>` and just using a `<div>` and some margins.

This is done for both `IFXBillingRecordList` and `IFXBillingRecordListDecimal`

This also includes a fix for the page header action area; divider line was hitting the action buttons. Same cause, namely that the `<v-row>` doesn't have a `<v-col>` after it to handle the -12px margins. In this case, we set the top/bottom margin to 0 and leave the left/right ones alone.