### PR TITLE
Pass thru `allowDownloads` flag to `IFXBillingRecordList`

### DIFF
--- a/src/components/billingRecord/IFXBillingRecords.vue
+++ b/src/components/billingRecord/IFXBillingRecords.vue
@@ -16,6 +16,11 @@ export default {
       required: false,
       default: true,
     },
+    allowDownloads: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
   },
   data() {
     return {
@@ -138,7 +143,7 @@ export default {
             :organization="organization"
             :allowInvoiceGeneration="false"
             :allowApprovals="false"
-            :allowDownloads="false"
+            :allowDownloads="allowDownloads"
             :useDefaultMailButton="useDefaultMailButton"
           />
           <IFXBillingRecordList
@@ -148,7 +153,7 @@ export default {
             :organization="organization"
             :allowInvoiceGeneration="false"
             :allowApprovals="false"
-            :allowDownloads="false"
+            :allowDownloads="allowDownloads"
             :useDefaultMailButton="useDefaultMailButton"
           />
         </v-col>


### PR DESCRIPTION
- This allows CBSN to download CSVs of the billing records