### PR TITLE
Fixes to new user management components

### DIFF
--- a/src/components/affiliation/IFXSelectAffiliation.vue
+++ b/src/components/affiliation/IFXSelectAffiliation.vue
@@ -13,18 +13,12 @@ export default {
   },
   mounted() {},
   computed: {
-    isContactSelected() {
-      return this.itemLocal.contact?.detail
-    },
     appropriateRoles() {
       // We assume that the type and the role name both contain the same case-senstive value
       return this.$api.user.userRoles.filter(
         (role) => this.$api.auth.can('edit-affiliations', this.$api.authUser) || role.value === 'member'
       )
     },
-    onlyOrgNames() {
-      return this.allItems.map((item) => this.$options.filters.orgNameFromSlug(item))
-    }
   },
   methods: {},
   watch: {
@@ -53,7 +47,7 @@ export default {
           <v-autocomplete
             v-model="itemLocal.organization"
             label="Search for an organization"
-            :items="onlyOrgNames"
+            :items="allItems"
             auto-select-first
             clearable
             clear-icon="mdi-close-circle"
@@ -65,6 +59,12 @@ export default {
             :rules="formRules.generic"
             :error-messages="errors['organization']"
           >
+            <template #item="{ item }">
+              {{ item | orgNameFromSlug }}
+            </template>
+            <template #selection="{ item }">
+              {{ item | orgNameFromSlug }}
+            </template>
           </v-autocomplete>
         </v-col>
       </v-row>

--- a/src/components/user/IFXUserInfoDialog.vue
+++ b/src/components/user/IFXUserInfoDialog.vue
@@ -50,10 +50,10 @@ export default {
     },
     changeCommentLocal: {
       get() {
-        return this.comment
+        return this.changeComment
       },
       set(text) {
-        this.$emit('update:comment', text)
+        this.$emit('update:changeComment', text)
       },
     },
   },


### PR DESCRIPTION
This PR fixes some issues with the new user detail management. The change comment is properly passed in and out of the `IFXUserInfoDialog` component and `IFXSelectAffiliation` returns the full slug but displays only the org name.
