### PR TITLE
Even admins have to use an expense code for billable resources

### DIFF
--- a/src/components/calendar/IFXCalendarList.vue
+++ b/src/components/calendar/IFXCalendarList.vue
@@ -200,7 +200,6 @@ export default {
         && this.resource?.billable
         && !(this.isMaintenance && this.useMaintenance)
         && !(this.trial && this.useTrial)
-        && !this.$api.auth.can('reserve-billable-without-code', this.$api.authUser)
       return result
     },
     expenseCodeEnabled() {


### PR DESCRIPTION
Remove permission check allowing admins to create reservations with an expense code. 