### PR TITLE
Bulk change expense code on Billing Record page

### DIFF
--- a/src/components/billingRecord/IFXBillingRecordHeader.vue
+++ b/src/components/billingRecord/IFXBillingRecordHeader.vue
@@ -51,7 +51,7 @@ export default {
       localRowSelectionToggle: [],
       showSummaryDetail: false,
       summaryButtonText: 'Show',
-      summaryDetails: []
+      summaryDetails: [],
     }
   },
   computed: {},
@@ -87,19 +87,20 @@ export default {
       ></v-checkbox>
       <div>
         <v-btn icon small @click="toggle">
-          <v-icon :class="{'active' : isOpen}">mdi-menu-right</v-icon>
+          <v-icon :class="{ active: isOpen }">mdi-menu-right</v-icon>
         </v-btn>
         <span class="group-header">
           {{ $api.organization.parseSlug(group).name }}
         </span>
         <span class="ml-3 font-weight-medium">Total charges: {{ summaryCharges | centsToDollars }}</span>
-        <v-btn small text @click="toggleSummaryDetail" class="ml-2">{{summaryButtonText}} Acct Summary</v-btn>
+        <v-btn small text @click="toggleSummaryDetail" class="ml-2">{{ summaryButtonText }} Acct Summary</v-btn>
       </div>
     </v-row>
     <v-row v-if="showSummaryDetail">
       <v-col class="py-1 ml-9">
         <v-row v-for="entry in summaryDetails" :key="`${group}-${entry[0]}`" class="text-body-2">
-          <v-col cols="5" class="ml-3">{{entry[0]}}</v-col><v-col class="text-xs-left ml-3 font-weight-medium">{{ entry[1] | centsToDollars}} </v-col>
+          <v-col cols="5" class="ml-3">{{ entry[0] }}</v-col>
+          <v-col class="text-xs-left ml-3 font-weight-medium">{{ entry[1] | centsToDollars }}</v-col>
         </v-row>
       </v-col>
     </v-row>

--- a/src/components/billingRecord/IFXBillingRecordHeaderDecimal.vue
+++ b/src/components/billingRecord/IFXBillingRecordHeaderDecimal.vue
@@ -51,7 +51,7 @@ export default {
       localRowSelectionToggle: [],
       showSummaryDetail: false,
       summaryButtonText: 'Show',
-      summaryDetails: []
+      summaryDetails: [],
     }
   },
   computed: {},
@@ -87,19 +87,20 @@ export default {
       ></v-checkbox>
       <div>
         <v-btn icon small @click="toggle">
-          <v-icon :class="{'active' : isOpen}">mdi-menu-right</v-icon>
+          <v-icon :class="{ active: isOpen }">mdi-menu-right</v-icon>
         </v-btn>
         <span class="group-header">
           {{ $api.organization.parseSlug(group).name }}
         </span>
         <span class="ml-3 font-weight-medium">Total charges: {{ summaryCharges | dollars }}</span>
-        <v-btn small text @click="toggleSummaryDetail" class="ml-2">{{summaryButtonText}} Acct Summary</v-btn>
+        <v-btn small text @click="toggleSummaryDetail" class="ml-2">{{ summaryButtonText }} Acct Summary</v-btn>
       </div>
     </v-row>
     <v-row v-if="showSummaryDetail">
       <v-col class="py-1 ml-9">
         <v-row v-for="entry in summaryDetails" :key="`${group}-${entry[0]}`" class="text-body-2">
-          <v-col cols="5" class="ml-3">{{entry[0]}}</v-col><v-col class="text-xs-left ml-3 font-weight-medium">{{ entry[1] | dollars}} </v-col>
+          <v-col cols="5" class="ml-3">{{ entry[0] }}</v-col>
+          <v-col class="text-xs-left ml-3 font-weight-medium">{{ entry[1] | dollars }}</v-col>
         </v-row>
       </v-col>
     </v-row>

--- a/src/components/billingRecord/IFXBillingRecordList.vue
+++ b/src/components/billingRecord/IFXBillingRecordList.vue
@@ -1248,23 +1248,22 @@ export default {
                       ></v-autocomplete>
                     </v-col>
                   </v-row>
-                  <v-row>
+                  <v-row class="records-container">
                     <v-col cols="12">
-                      <div class="text-h6 text-center pb-3">Select the billing records to change</div>
-                      <div v-for="record in selected" :key="record.id">
-                        <v-checkbox v-model="recordIDsToBeChanged" :value="record.id">
-                          <template v-slot:label>
-                            <div class="font-weight-medium mr-3">Billing Record #{{ record.id }}</div>
-                            <div class="font-weight-regular">({{ record.account.name }})"</div>
-                          </template>
-                        </v-checkbox>
-                        <div class="font-weight-light mt-n5 mb-5">({{ record.description }})"</div>
-                      </div>
+                      <ul class="text-body-1">
+                        <li v-for="record in selected" :key="record.id">
+                          <div class="font-weight-medium mr-3">
+                            Billing Record #{{ record.id }}
+                            <span class="font-weight-regular">({{ record.account.name }})"</span>
+                          </div>
+                          <div class="font-weight-light mb-5">({{ record.description }})"</div>
+                        </li>
+                      </ul>
                     </v-col>
                   </v-row>
-                  <v-divider></v-divider>
                 </v-form>
               </v-card-text>
+              <v-divider></v-divider>
               <v-card-actions>
                 <div v-if="updating">
                   <span class="mr-3">Updating billing records...</span>
@@ -1284,6 +1283,10 @@ export default {
 <style lang="scss" scoped>
 .w-full {
   width: 100%;
+}
+.records-container {
+  max-height: 50vh;
+  overflow: auto;
 }
 .message-text {
   font-size: smaller;

--- a/src/components/billingRecord/IFXBillingRecordList.vue
+++ b/src/components/billingRecord/IFXBillingRecordList.vue
@@ -59,7 +59,7 @@ export default {
     allowChangeExpenseCode: {
       type: Boolean,
       required: false,
-      default: false,
+      default: true,
     },
     useDefaultMailButton: {
       type: Boolean,
@@ -761,7 +761,7 @@ export default {
   <v-container>
     <v-card>
       <v-card-title>
-        <v-row class="d-flex justify-space-between">
+        <v-row class="d-flex justify-space-between w-full">
           <v-col cols="4">
             <div class="text-no-wrap">
               {{ facility.name }}
@@ -1282,6 +1282,9 @@ export default {
   </v-container>
 </template>
 <style lang="scss" scoped>
+.w-full {
+  width: 100%;
+}
 .message-text {
   font-size: smaller;
   font-style: italic;

--- a/src/components/billingRecord/IFXBillingRecordList.vue
+++ b/src/components/billingRecord/IFXBillingRecordList.vue
@@ -1,7 +1,7 @@
 <script>
-import moment from 'moment'
 import { mapActions } from 'vuex'
 import cloneDeep from 'lodash/cloneDeep'
+import moment from 'moment'
 
 import IFXBillingRecordMixin from '@/components/billingRecord/IFXBillingRecordMixin'
 import IFXButton from '@/components/IFXButton'
@@ -91,7 +91,6 @@ export default {
       })
       .then(async () => {
         this.expenseCodes = await this.$api.account.getList()
-        // console.log('got codes ', this.expenseCodes)
       })
       .finally(() => (this.isLoading = false))
   },
@@ -129,7 +128,7 @@ export default {
               return a.productUsage.id - b.productUsage.id
             }
             return 0
-          }
+          },
         },
         { text: 'Transaction Description', value: 'transactions', sortable: false },
         { text: 'Actions', value: 'actions', sortable: false },
@@ -675,7 +674,6 @@ export default {
       this.showChangeExpenseCodeDialog = true
     },
     closeChangeExpenseCodeDialog() {
-      this.newExpenseCode = {}
       this.recordIDsToBeChanged = []
       this.showChangeExpenseCodeDialog = false
     },
@@ -776,7 +774,7 @@ export default {
               </v-col>
             </v-row>
           </v-col>
-          <v-col cols="5">
+          <v-col cols="4">
             <v-row dense class="d-flex flex-nowrap justify-end align-start">
               <v-col v-if="updating">
                 <v-progress-circular indeterminate color="primary"></v-progress-circular>
@@ -1105,13 +1103,13 @@ export default {
               </span>
             </template>
             <template v-slot:item.endDate="{ item }">
-              <span  class="text-no-wrap">
+              <span class="text-no-wrap">
                 {{ item.endDate | humanDatetime }}
               </span>
             </template>
             <template v-slot:item.productUsage="{ item }">
               <span v-if="item.productUsageLinkText" class="text-no-wrap">
-                <a :href="item.productUsageUrl">{{item.productUsageLinkText}}</a>
+                <a :href="item.productUsageUrl">{{ item.productUsageLinkText }}</a>
               </span>
               <span v-else class="text-no-wrap">
                 {{ item.productUsage.id }}
@@ -1250,7 +1248,6 @@ export default {
                       ></v-autocomplete>
                     </v-col>
                   </v-row>
-                  <v-divider></v-divider>
                   <v-row>
                     <v-col cols="12">
                       <div class="text-h6 text-center pb-3">Select the billing records to change</div>

--- a/src/components/billingRecord/IFXBillingRecordList.vue
+++ b/src/components/billingRecord/IFXBillingRecordList.vue
@@ -56,6 +56,11 @@ export default {
       required: false,
       default: false,
     },
+    allowChangeExpenseCode: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
     useDefaultMailButton: {
       type: Boolean,
       required: false,
@@ -78,6 +83,10 @@ export default {
         const errorMessage = this.getErrorMessage(error)
         this.messageType = 'error'
         this.message = `Error loading ${this.facility.name} billing records: ${errorMessage}`
+      })
+      .then(async () => {
+        this.expenseCodes = await this.$api.account.getList()
+        // console.log('got codes ', this.expenseCodes)
       })
       .finally(() => (this.isLoading = false))
   },
@@ -113,6 +122,7 @@ export default {
       search: null,
       isValidTxn: false,
       isValidEdit: false,
+      isValidBulkEdit: false,
       txnDialog: false,
       editDialog: false,
       notifyDialog: false,
@@ -140,6 +150,8 @@ export default {
       sendingNotifications: false,
       emailResponse: null,
       newExpenseCode: null,
+      showChangeExpenseCodeDialog: false,
+      recordIDsToBeChanged: [],
     }
   },
   computed: {
@@ -415,7 +427,7 @@ export default {
     },
     summaryCharges(group) {
       const records = this.filteredItems.filter((item) => item.account.organization === group)
-      const summary = records.reduce((prev, current) => prev + current.charge, 0)
+      const summary = records.reduce((prev, current) => prev + parseInt(current.decimalCharge, 10), 0)
       return summary
     },
     getSummaryDetails(group) {
@@ -540,14 +552,12 @@ export default {
           this.updating = false
           this.txnDialog = false
           this.editDialog = false
+          this.showChangeExpenseCodeDialog = false
         })
     },
     async openEditDialog(item) {
       const index = this.items.findIndex((rec) => rec.id === item.id)
       if (index !== -1) {
-        this.expenseCodes = await this.$api.account.getList()
-        console.log('got codes ', this.expenseCodes)
-
         this.editingIndex = index
         this.editedRecord = cloneDeep(item)
         this.newExpenseCode = await this.$api.account.create(item.account)
@@ -640,6 +650,84 @@ export default {
       }
       return list
     },
+    async openChangeExpenseCodeDialog() {
+      // Assume they want to change all records they've selected
+      this.recordIDsToBeChanged = this.selected.map((record) => record.id)
+      this.showChangeExpenseCodeDialog = true
+    },
+    closeChangeExpenseCodeDialog() {
+      this.newExpenseCode = {}
+      this.recordIDsToBeChanged = []
+      this.showChangeExpenseCodeDialog = false
+    },
+    async changeExpenseCode() {
+      const recordsToChange = []
+      const groups = new Set()
+      this.updating = true
+      for (let i = 0; i < this.recordIDsToBeChanged.length; i++) {
+        const index = this.items.findIndex((rec) => rec.id === this.recordIDsToBeChanged[i])
+        const newBillingRec = cloneDeep(await this.getFullBillingRecordByItemIndex(index))
+        newBillingRec.account = this.newExpenseCode.data
+        recordsToChange.push(newBillingRec)
+      }
+      this.$api.billingRecord
+        .bulkUpdate(recordsToChange, this.facility.applicationUsername)
+        .then((response) => {
+          if (response.error) {
+            this.showMessage(response.error)
+          } else {
+            // Replace all the new billing records
+            response.data.forEach((record) => {
+              const newBillingRec = this.$api.billingRecord.create(record)
+              let index = this.items.findIndex((rec) => rec.id === record.id)
+              this.items.splice(index, 1, newBillingRec)
+              // Now replace the records in the selected array
+              index = this.selected.findIndex((rec) => rec.id === record.id)
+              // Save potentially old org
+              groups.add(this.selected[index].account.organization)
+              this.selected.splice(index, 1, newBillingRec)
+              // Save the (deduped) org for setting the header checkboxes
+              groups.add(newBillingRec.account.organization)
+            })
+            // Now set the header checkboxes
+            Array.from(groups).forEach((org) => {
+              this.setHeaderCheckBoxState(org)
+            })
+            this.showMessage(`Successfully updated ${response.data.length} billing record(s)`)
+          }
+        })
+        .catch((error) => {
+          const message = this.getErrorMessage(error)
+          this.showMessage(message)
+        })
+        .finally(() => {
+          this.isLoading = false
+          this.updating = false
+          this.closeChangeExpenseCodeDialog()
+        })
+    },
+    setHeaderCheckBoxState(group) {
+      const records = this.filteredItems.filter((item) => item.account.organization === group)
+      const checked = this.selected.filter((item) => item.account.organization === group).length
+      const state = checked !== 0 && checked < records.length
+      this.$set(this.rowSelectionToggleIndeterminate, group, state)
+      // Now set the checkbox model to the correct state
+      if (checked) {
+        if (checked === records.length) {
+          // All are checked so add this if it isn't already there
+          const index = this.rowSelectionToggle.indexOf(group)
+          if (index === -1) {
+            this.rowSelectionToggle.push(group)
+          }
+        }
+      } else {
+        // None are checked so remove this group
+        const index = this.rowSelectionToggle.indexOf(group)
+        if (index !== -1) {
+          this.rowSelectionToggle.splice(index, 1)
+        }
+      }
+    },
   },
   watch: {
     filteredItems() {
@@ -669,7 +757,7 @@ export default {
               </v-col>
             </v-row>
           </v-col>
-          <v-col cols="4">
+          <v-col cols="5">
             <v-row dense class="d-flex flex-nowrap justify-end align-start">
               <v-col v-if="updating">
                 <v-progress-circular indeterminate color="primary"></v-progress-circular>
@@ -861,6 +949,26 @@ export default {
                         </v-tooltip>
                       </v-col>
                     </v-row>
+                  </v-col>
+                  <v-col v-if="allowChangeExpenseCode">
+                    <v-tooltip top>
+                      <template v-slot:activator="{ on, attrs }">
+                        <div v-on="on">
+                          <v-btn
+                            :disabled="selected.length == 0 || billingRecordsAreFinal(selected)"
+                            v-bind="attrs"
+                            fab
+                            small
+                            color="green"
+                            @click="openChangeExpenseCodeDialog()"
+                          >
+                            <!-- <v-icon dark>mdi-file-replace-outline</v-icon> -->
+                            <v-icon dark>mdi-playlist-edit</v-icon>
+                          </v-btn>
+                        </div>
+                      </template>
+                      <span>{{ approveSelectedToolTip }}</span>
+                    </v-tooltip>
                   </v-col>
                   <v-col class="pa-2" v-if="allowInvoiceGeneration">
                     <v-row dense>
@@ -1085,6 +1193,56 @@ export default {
                 <v-btn color="blue darken-1" text :disabled="!isValidEdit" @click="updateSpecificRecord(editedRecord)">
                   Save
                 </v-btn>
+              </v-card-actions>
+            </v-card>
+          </v-dialog>
+          <v-dialog v-model="showChangeExpenseCodeDialog" v-if="showChangeExpenseCodeDialog" max-width="600px">
+            <v-card>
+              <v-card-title>
+                <span class="text-h5">Edit Selected Billing Records</span>
+              </v-card-title>
+              <v-card-text>
+                <v-form v-model="isValidBulkEdit">
+                  <v-row>
+                    <v-col>
+                      <v-autocomplete
+                        required
+                        v-model="newExpenseCode"
+                        :items="expenseCodes"
+                        item-text="slug"
+                        label="New Expense Code / PO"
+                        :error-messages="errors[newExpenseCode]"
+                        :rules="formRules.generic"
+                        return-object
+                      ></v-autocomplete>
+                    </v-col>
+                  </v-row>
+                  <v-divider></v-divider>
+                  <v-row>
+                    <v-col cols="12">
+                      <div class="text-h6 text-center pb-3">Select the billing records to change</div>
+                      <div v-for="record in selected" :key="record.id">
+                        <v-checkbox v-model="recordIDsToBeChanged" :value="record.id">
+                          <template v-slot:label>
+                            <div class="font-weight-medium mr-3">Billing Record #{{ record.id }}</div>
+                            <div class="font-weight-regular">({{ record.account.name }})"</div>
+                          </template>
+                        </v-checkbox>
+                        <div class="font-weight-light mt-n5 mb-5">({{ record.description }})"</div>
+                      </div>
+                    </v-col>
+                  </v-row>
+                  <v-divider></v-divider>
+                </v-form>
+              </v-card-text>
+              <v-card-actions>
+                <div v-if="updating">
+                  <span class="mr-3">Updating billing records...</span>
+                  <v-progress-circular indeterminate color="primary"></v-progress-circular>
+                </div>
+                <v-spacer></v-spacer>
+                <v-btn color="secondary" text @click="closeChangeExpenseCodeDialog">Cancel</v-btn>
+                <v-btn color="blue darken-1" text :disabled="!isValidBulkEdit" @click="changeExpenseCode">Save</v-btn>
               </v-card-actions>
             </v-card>
           </v-dialog>

--- a/src/components/billingRecord/IFXBillingRecordListDecimal.vue
+++ b/src/components/billingRecord/IFXBillingRecordListDecimal.vue
@@ -1246,23 +1246,22 @@ export default {
                       ></v-autocomplete>
                     </v-col>
                   </v-row>
-                  <v-row>
+                  <v-row class="records-container">
                     <v-col cols="12">
-                      <div class="text-h6 text-center pb-3">Select the billing records to change</div>
-                      <div v-for="record in selected" :key="record.id">
-                        <v-checkbox v-model="recordIDsToBeChanged" :value="record.id">
-                          <template v-slot:label>
-                            <div class="font-weight-medium mr-3">Billing Record #{{ record.id }}</div>
-                            <div class="font-weight-regular">({{ record.account.name }})"</div>
-                          </template>
-                        </v-checkbox>
-                        <div class="font-weight-light mt-n5 mb-5">({{ record.description }})"</div>
-                      </div>
+                      <ul class="text-body-1">
+                        <li v-for="record in selected" :key="record.id">
+                          <div class="font-weight-medium mr-3">
+                            Billing Record #{{ record.id }}
+                            <span class="font-weight-regular">({{ record.account.name }})"</span>
+                          </div>
+                          <div class="font-weight-light mb-5">({{ record.description }})"</div>
+                        </li>
+                      </ul>
                     </v-col>
                   </v-row>
-                  <v-divider></v-divider>
                 </v-form>
               </v-card-text>
+              <v-divider></v-divider>
               <v-card-actions>
                 <div v-if="updating">
                   <span class="mr-3">Updating billing records...</span>
@@ -1282,6 +1281,10 @@ export default {
 <style lang="scss" scoped>
 .w-full {
   width: 100%;
+}
+.records-container {
+  max-height: 50vh;
+  overflow: auto;
 }
 .message-text {
   font-size: smaller;

--- a/src/components/billingRecord/IFXBillingRecordListDecimal.vue
+++ b/src/components/billingRecord/IFXBillingRecordListDecimal.vue
@@ -18,7 +18,7 @@ export default {
     IFXBillingRecordTransactionsDecimal,
     IFXContactablesCombobox,
     IFXMailButton,
-    IFXBillingRecordHeaderDecimal
+    IFXBillingRecordHeaderDecimal,
   },
   mixins: [IFXBillingRecordMixin],
   filters: {
@@ -307,7 +307,7 @@ export default {
           if (i !== 0 && i % this.promiseBatchSize === 0) {
             // Wait a bit to not overwhelm the backend
             /* eslint-disable no-await-in-loop */
-            await new Promise(r => setTimeout(r, 500));
+            await new Promise((r) => setTimeout(r, 500))
           }
         } else {
           item.billingRecordStates.push({ name: state, user: '', approvers: [], comment: '' })
@@ -315,7 +315,7 @@ export default {
         }
       }
       const results = await Promise.all(promises)
-      results.forEach(item => {
+      results.forEach((item) => {
         item.billingRecordStates.push({ name: state, user: '', approvers: [], comment: '' })
         toBeUpdated.push(item)
       })
@@ -743,7 +743,10 @@ export default {
                                           </li>
                                         </ul>
                                       </div>
-                                      <div v-if="Object.keys(emailResponse.errors).length" class="my-3 pb-2 border-bottom">
+                                      <div
+                                        v-if="Object.keys(emailResponse.errors).length"
+                                        class="my-3 pb-2 border-bottom"
+                                      >
                                         The following
                                         <span class="red--text">errors</span>
                                         occurred trying to send emails:
@@ -774,7 +777,9 @@ export default {
                               </v-card-text>
                               <v-card-actions>
                                 <v-spacer></v-spacer>
-                                <v-btn color="secondary" text @click="notifyDialog = false">{{emailResponse ? "Close" : "Cancel"}}</v-btn>
+                                <v-btn color="secondary" text @click="notifyDialog = false">
+                                  {{ emailResponse ? 'Close' : 'Cancel' }}
+                                </v-btn>
                                 <v-btn color="blue darken-1" text :disabled="!isValid" @click="notifyLabManagers">
                                   Notify
                                 </v-btn>
@@ -897,27 +902,27 @@ export default {
       </v-card-title>
       <v-row>
         <v-col id="data-table">
-            <v-data-table
-              ref="table"
-              v-if="filteredItems"
-              v-model="selected"
-              :items="filteredItems"
-              :headers="headers"
-              :show-select="showCheckboxes"
-              show-expand
-              expand-icon="mdi-menu-right"
-              :itemKey="itemKey"
-              :loading="isLoading"
-              :items-per-page="-1"
-              group-by="account.organization"
-              @item-selected="determineGroupState"
-              @toggle-select-all="toggleSelectAll"
-            >
-              <template
+          <v-data-table
+            ref="table"
+            v-if="filteredItems"
+            v-model="selected"
+            :items="filteredItems"
+            :headers="headers"
+            :show-select="showCheckboxes"
+            show-expand
+            expand-icon="mdi-menu-right"
+            :itemKey="itemKey"
+            :loading="isLoading"
+            :items-per-page="-1"
+            group-by="account.organization"
+            @item-selected="determineGroupState"
+            @toggle-select-all="toggleSelectAll"
+          >
+            <template
               v-slot:group.header="{ group, headers, isOpen, toggle }"
               v-on:rendered="itemRendered('group.header')"
             >
-                <IFXBillingRecordHeaderDecimal
+              <IFXBillingRecordHeaderDecimal
                 :key="group"
                 :item="item"
                 :group="group"
@@ -932,7 +937,7 @@ export default {
                 :getSummaryDetails="getSummaryDetails"
                 @
               />
-              </template>
+            </template>
             <template v-slot:item.id="{ item }">
               <a href="" @click.prevent="navigateToDetail(item.id)">{{ item.id }}</a>
             </template>
@@ -968,6 +973,7 @@ export default {
               <span style="white-space: nowrap">
                 {{ item.endDate | humanDatetime }}
               </span>
+            </template>
             <template v-slot:item.actions="{ item }">
               <div class="d-flex flex-row">
                 <IFXButton
@@ -990,7 +996,7 @@ export default {
             <template v-slot:expanded-item="{ item }">
               <IFXBillingRecordTransactionsDecimal :billingRecord="item" />
             </template>
-            </v-data-table>
+          </v-data-table>
           <v-dialog v-model="txnDialog" max-width="600px">
             <v-card>
               <v-card-title>

--- a/src/components/billingRecord/IFXBillingRecordListDecimal.vue
+++ b/src/components/billingRecord/IFXBillingRecordListDecimal.vue
@@ -59,7 +59,7 @@ export default {
     allowChangeExpenseCode: {
       type: Boolean,
       required: false,
-      default: false,
+      default: true,
     },
     useDefaultMailButton: {
       type: Boolean,
@@ -764,7 +764,7 @@ export default {
   <v-container>
     <v-card>
       <v-card-title>
-        <v-row class="d-flex justify-space-between">
+        <v-row class="d-flex justify-space-between w-full">
           <v-col cols="4">
             <div class="text-no-wrap">
               {{ facility.name }}
@@ -1280,6 +1280,9 @@ export default {
   </v-container>
 </template>
 <style lang="scss" scoped>
+.w-full {
+  width: 100%;
+}
 .message-text {
   font-size: smaller;
   font-style: italic;

--- a/src/components/billingRecord/IFXBillingRecordListDecimal.vue
+++ b/src/components/billingRecord/IFXBillingRecordListDecimal.vue
@@ -987,7 +987,7 @@ export default {
                           </v-btn>
                         </div>
                       </template>
-                      <span>{{ approveSelectedToolTip }}</span>
+                      <span>Edit billing record account</span>
                     </v-tooltip>
                   </v-col>
                   <v-col class="pa-2" v-if="allowInvoiceGeneration">

--- a/src/components/billingRecord/IFXBillingRecordListDecimal.vue
+++ b/src/components/billingRecord/IFXBillingRecordListDecimal.vue
@@ -55,6 +55,11 @@ export default {
       required: false,
       default: false,
     },
+    allowChangeExpenseCode: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
     useDefaultMailButton: {
       type: Boolean,
       required: false,
@@ -77,6 +82,10 @@ export default {
         const errorMessage = this.getErrorMessage(error)
         this.messageType = 'error'
         this.message = `Error loading ${this.facility.name} billing records: ${errorMessage}`
+      })
+      .then(async () => {
+        this.expenseCodes = await this.$api.account.getList()
+        // console.log('got codes ', this.expenseCodes)
       })
       .finally(() => (this.isLoading = false))
   },
@@ -112,6 +121,7 @@ export default {
       search: null,
       isValidTxn: false,
       isValidEdit: false,
+      isValidBulkEdit: false,
       txnDialog: false,
       editDialog: false,
       notifyDialog: false,
@@ -141,6 +151,8 @@ export default {
       sendingNotifications: false,
       emailResponse: null,
       newExpenseCode: null,
+      showChangeExpenseCodeDialog: false,
+      recordIDsToBeChanged: [],
     }
   },
   computed: {
@@ -414,7 +426,7 @@ export default {
     },
     summaryCharges(group) {
       const records = this.filteredItems.filter((item) => item.account.organization === group)
-      const summary = records.reduce((prev, current) => prev + current.decimalCharge, 0)
+      const summary = records.reduce((prev, current) => prev + parseInt(current.decimalCharge, 10), 0)
       return summary
     },
     getSummaryDetails(group) {
@@ -540,6 +552,7 @@ export default {
           this.updating = false
           this.txnDialog = false
           this.editDialog = false
+          this.showChangeExpenseCodeDialog = false
         })
     },
     async openEditDialog(item) {
@@ -637,6 +650,84 @@ export default {
         list = 'Lab managers'
       }
       return list
+    },
+    async openChangeExpenseCodeDialog() {
+      // Assume they want to change all records they've selected
+      this.recordIDsToBeChanged = this.selected.map((record) => record.id)
+      this.showChangeExpenseCodeDialog = true
+    },
+    closeChangeExpenseCodeDialog() {
+      // this.newExpenseCode = {}
+      this.recordIDsToBeChanged = []
+      this.showChangeExpenseCodeDialog = false
+    },
+    async changeExpenseCode() {
+      const recordsToChange = []
+      const groups = new Set()
+      this.updating = true
+      for (let i = 0; i < this.recordIDsToBeChanged.length; i++) {
+        const index = this.items.findIndex((rec) => rec.id === this.recordIDsToBeChanged[i])
+        const newBillingRec = cloneDeep(await this.getFullBillingRecordByItemIndex(index))
+        newBillingRec.account = this.newExpenseCode.data
+        recordsToChange.push(newBillingRec)
+      }
+      this.$api.billingRecord
+        .bulkUpdate(recordsToChange, this.facility.applicationUsername)
+        .then((response) => {
+          if (response.error) {
+            this.showMessage(response.error)
+          } else {
+            // Replace all the new billing records
+            response.data.forEach((record) => {
+              const newBillingRec = this.$api.billingRecord.create(record)
+              let index = this.items.findIndex((rec) => rec.id === record.id)
+              this.items.splice(index, 1, newBillingRec)
+              // Now replace the records in the selected array
+              index = this.selected.findIndex((rec) => rec.id === record.id)
+              // Save potentially old org
+              groups.add(this.selected[index].account.organization)
+              this.selected.splice(index, 1, newBillingRec)
+              // Save the (deduped) org for setting the header checkboxes
+              groups.add(newBillingRec.account.organization)
+            })
+            // Now set the header checkboxes
+            Array.from(groups).forEach((org) => {
+              this.setHeaderCheckBoxState(org)
+            })
+            this.showMessage(`Successfully updated ${response.data.length} billing record(s)`)
+          }
+        })
+        .catch((error) => {
+          const message = this.getErrorMessage(error)
+          this.showMessage(message)
+        })
+        .finally(() => {
+          this.isLoading = false
+          this.updating = false
+          this.closeChangeExpenseCodeDialog()
+        })
+    },
+    setHeaderCheckBoxState(group) {
+      const records = this.filteredItems.filter((item) => item.account.organization === group)
+      const checked = this.selected.filter((item) => item.account.organization === group).length
+      const state = checked !== 0 && checked < records.length
+      this.$set(this.rowSelectionToggleIndeterminate, group, state)
+      // Now set the checkbox model to the correct state
+      if (checked) {
+        if (checked === records.length) {
+          // All are checked so add this if it isn't already there
+          const index = this.rowSelectionToggle.indexOf(group)
+          if (index === -1) {
+            this.rowSelectionToggle.push(group)
+          }
+        }
+      } else {
+        // None are checked so remove this group
+        const index = this.rowSelectionToggle.indexOf(group)
+        if (index !== -1) {
+          this.rowSelectionToggle.splice(index, 1)
+        }
+      }
     },
   },
   watch: {
@@ -859,6 +950,26 @@ export default {
                         </v-tooltip>
                       </v-col>
                     </v-row>
+                  </v-col>
+                  <v-col v-if="allowChangeExpenseCode">
+                    <v-tooltip top>
+                      <template v-slot:activator="{ on, attrs }">
+                        <div v-on="on">
+                          <v-btn
+                            :disabled="selected.length == 0 || billingRecordsAreFinal(selected)"
+                            v-bind="attrs"
+                            fab
+                            small
+                            color="green"
+                            @click="openChangeExpenseCodeDialog()"
+                          >
+                            <!-- <v-icon dark>mdi-file-replace-outline</v-icon> -->
+                            <v-icon dark>mdi-playlist-edit</v-icon>
+                          </v-btn>
+                        </div>
+                      </template>
+                      <span>{{ approveSelectedToolTip }}</span>
+                    </v-tooltip>
                   </v-col>
                   <v-col class="pa-2" v-if="allowInvoiceGeneration">
                     <v-row dense>
@@ -1083,6 +1194,55 @@ export default {
                 <v-btn color="blue darken-1" text :disabled="!isValidEdit" @click="updateSpecificRecord(editedRecord)">
                   Save
                 </v-btn>
+              </v-card-actions>
+            </v-card>
+          </v-dialog>
+          <v-dialog v-model="showChangeExpenseCodeDialog" v-if="showChangeExpenseCodeDialog" max-width="600px">
+            <v-card>
+              <v-card-title>
+                <span class="text-h5">Edit Selected Billing Records</span>
+              </v-card-title>
+              <v-card-text>
+                <v-form v-model="isValidBulkEdit">
+                  <v-row>
+                    <v-col>
+                      <v-autocomplete
+                        required
+                        v-model="newExpenseCode"
+                        :items="expenseCodes"
+                        item-text="slug"
+                        label="New Expense Code / PO"
+                        :error-messages="errors[newExpenseCode]"
+                        :rules="formRules.generic"
+                        return-object
+                      ></v-autocomplete>
+                    </v-col>
+                  </v-row>
+                  <v-row>
+                    <v-col cols="12">
+                      <div class="text-h6 text-center pb-3">Select the billing records to change</div>
+                      <div v-for="record in selected" :key="record.id">
+                        <v-checkbox v-model="recordIDsToBeChanged" :value="record.id">
+                          <template v-slot:label>
+                            <div class="font-weight-medium mr-3">Billing Record #{{ record.id }}</div>
+                            <div class="font-weight-regular">({{ record.account.name }})"</div>
+                          </template>
+                        </v-checkbox>
+                        <div class="font-weight-light mt-n5 mb-5">({{ record.description }})"</div>
+                      </div>
+                    </v-col>
+                  </v-row>
+                  <v-divider></v-divider>
+                </v-form>
+              </v-card-text>
+              <v-card-actions>
+                <div v-if="updating">
+                  <span class="mr-3">Updating billing records...</span>
+                  <v-progress-circular indeterminate color="primary"></v-progress-circular>
+                </div>
+                <v-spacer></v-spacer>
+                <v-btn color="secondary" text @click="closeChangeExpenseCodeDialog">Cancel</v-btn>
+                <v-btn color="blue darken-1" text :disabled="!isValidBulkEdit" @click="changeExpenseCode">Save</v-btn>
               </v-card-actions>
             </v-card>
           </v-dialog>

--- a/src/components/message/IFXMessageList.vue
+++ b/src/components/message/IFXMessageList.vue
@@ -15,6 +15,7 @@ export default {
     headers() {
       const headers = [
         { text: 'ID', value: 'id', sortable: true },
+        { text: 'Name', value: 'displayName', sortable: true },
         { text: 'Subject', value: 'subject' },
         { text: 'Message', value: 'message' },
         { text: '', value: 'rowActionEdit', slot: true },


### PR DESCRIPTION
This PR implements the bulk changing of expense code/POs on the Billing Records page. This feature is controlled via a prop, `allowChangeExpenseCode` and allows the user to select a group of billing records and an expense code/PO and change all the existing expense codes to the new one. The records remain selected after the operation is complete. Changes take place immediately, similar to how the individual expense code feature works.

The bulk change dialog lists all the records and includes the descriptions so the user can verify that they are changing the proper records. Each record can be deselected if necessary.

This capability should be the same in both the regular and the Decimal Billing Records page.