### PR TITLE
Fix v-if calls for editing records and transactions

### DIFF
--- a/src/components/billingRecord/IFXBillingRecordDetail.vue
+++ b/src/components/billingRecord/IFXBillingRecordDetail.vue
@@ -192,7 +192,7 @@ export default {
     <IFXPageHeader>
       <template #title>Billing Record {{ item.id }}</template>
       <template #actions>
-        <IFXButton v-if="canEdit" btnType="edit" xSmall @action="openEditDialog()" />
+        <IFXButton v-if="canEdit()" btnType="edit" xSmall @action="openEditDialog()" />
       </template>
     </IFXPageHeader>
     <v-container px-5 py-0>
@@ -298,7 +298,7 @@ export default {
         <v-col>
           <div class="d-flex justify-space-between">
             <h3>Transactions</h3>
-            <IFXButton v-if="canAddTransaction" iconString="add" btnType="add" xSmall @action="openTxnDialog(item)" />
+            <IFXButton v-if="canAddTransaction()" iconString="add" btnType="add" xSmall @action="openTxnDialog(item)" />
           </div>
         </v-col>
       </v-row>


### PR DESCRIPTION
This PR fixes an issue where the "Edit Billing Record" and "Add Transactions" buttons would be displayed for records in the `FINAL` state. This was caused by the `v-if` check on both buttons using just the name of the method rather than calling the method. Listing just the name works fine with computed variables but for methods, you have to put in the `()` to call it.
