### PR TITLE
Redo Contact List page

### DIFF
--- a/src/components/contact/IFXContactCard.vue
+++ b/src/components/contact/IFXContactCard.vue
@@ -56,7 +56,7 @@ export default {
         <!-- So that contacts on the OrganizationDetail page don't see blank space -->
         <v-col alignContent="start" justify="start">
           <v-row>
-            <div class="headline">{{ contactData.org }} ({{ contactData.name }})</div>
+            <div class="headline mr-8">{{ contactData.org }} ({{ contactData.name }})</div>
           </v-row>
         </v-col>
       </v-card-title>
@@ -64,7 +64,7 @@ export default {
       <v-card-title xs-12 v-else-if="contactData.name">
         <v-col>
           <v-row>
-            <div class="headline">
+            <div class="headline mr-8">
               <router-link v-if="contactData.userId" :to="{ name: 'UserEdit', params: { id: contactData.userId } }">
                 {{ contactData.name }}
               </router-link>

--- a/src/components/contact/IFXContactList.vue
+++ b/src/components/contact/IFXContactList.vue
@@ -28,8 +28,11 @@ export default {
     },
     composeEmail() {
       const recipients = this.selected.map((item) => item.detail).join(',')
-      this.$router.push({ name: 'MailingCompose', params: { recipients: recipients, recipientField: this.recipientField } })
-    }
+      this.$router.push({
+        name: 'MailingCompose',
+        params: { recipients: recipients, recipientField: this.recipientField },
+      })
+    },
   },
   computed: {
     headers() {
@@ -43,20 +46,13 @@ export default {
     isContactContentLarge() {
       return !!this.$vuetify.breakpoint.mdAndUp
     },
-    contactContentStyle() {
-      return {
-        display: 'flex',
-        'flex-direction': this.isContactContentLarge ? 'row' : 'column',
-        width: '600px'
-      }
-    }
   },
   mounted() {
     this.isLoading = true
     this.getSetItems()
-      .then(() => this.focusedContact = this.items[0])
-      .then(() => this.isLoading = false)
-  }
+      .then(() => (this.focusedContact = this.items[0]))
+      .then(() => (this.isLoading = false))
+  },
 }
 </script>
 <style lang="scss" scoped>
@@ -65,13 +61,13 @@ export default {
 }
 </style>
 <template>
-  <v-container v-if="!isLoading" fluid  grid-list-md>
+  <v-container v-if="!isLoading" fluid grid-list-md>
     <IFXPageHeader>
-      <template #title>{{listTitle}}</template>
+      <template #title>{{ listTitle }}</template>
       <template #actions>
         <v-row nowrap align="center">
           <v-col>
-            <IFXSearchField :search.sync='search'/>
+            <IFXSearchField :search.sync="search" />
           </v-col>
           <v-col>
             <IFXMailButton
@@ -79,42 +75,41 @@ export default {
               toolTip="Email contacts"
               :disabled="!selected.length"
               @input="composeEmail()"
-            >
-            </IFXMailButton>
+            ></IFXMailButton>
           </v-col>
           <v-col>
-            <IFXButton small btnType="add" @action="navigateToItemCreate"/>
+            <IFXButton small btnType="add" @action="navigateToItemCreate" />
           </v-col>
         </v-row>
       </template>
     </IFXPageHeader>
-    <div :style='contactContentStyle'>
-      <IFXItemDataTable
-        class="full-width"
-        :items='filteredItems'
-        :headers='headers'
-        :selected.sync='selected'
-        :itemType='itemType'
-        itemKey='key'
-        @click-row='setFocusedContact'
-      >
-        <template v-slot:created="{ item }">
-          <span style="white-space: nowrap;">{{ item.created|humanDatetime }}</span>
-        </template>
-      </IFXItemDataTable>
-    </div>
-    <div class="contact-card">
-      <IFXContactCard :dense="isContactContentLarge" :contact="focusedContact"/>
+    <div class="d-flex flex-column-reverse flex-lg-row">
+      <div>
+        <IFXItemDataTable
+          class="full-width"
+          :items="filteredItems"
+          :headers="headers"
+          :selected.sync="selected"
+          :itemType="itemType"
+          itemKey="key"
+          @click-row="setFocusedContact"
+        >
+          <template v-slot:created="{ item }">
+            <span style="white-space: nowrap">{{ item.created | humanDatetime }}</span>
+          </template>
+        </IFXItemDataTable>
+      </div>
+      <div class="contact-card ml-auto ml-lg-3 mr-3">
+        <IFXContactCard :dense="isContactContentLarge" :contact="focusedContact" />
+      </div>
     </div>
   </v-container>
 </template>
-<style scoped>
-  .contact-card {
-    position: fixed;
-    right: 0.5em;
-    top: 300px;
-    background-color: white;
-    z-index: 1000;
-    width: 500px;
-  }
+<style lang="scss" scoped>
+.contact-card {
+  position: sticky;
+  top: 75px;
+  background-color: white;
+  width: 500px;
+}
 </style>


### PR DESCRIPTION
This PR re-lays out the Contact List Page. The Contact Card is now `position: sticky` so it stays within the card containing the contact list but won't scroll off the page. It is still on the right for wide enough viewports but moves to the top once the viewport shrinks. This will overlap the list for very small screens but can't be helped; since it is still right-aligned, it should be possible to select contacts.

The Contact Card now adds some right margin so long org/names don't run under the edit button.
