### PR TITLE
Billing dates

### DIFF
--- a/src/components/billingRecord/IFXBillingRecord.js
+++ b/src/components/billingRecord/IFXBillingRecord.js
@@ -189,11 +189,11 @@ export default class BillingRecord extends IFXItemBase {
   }
 
   get startDate() {
-    return this.productUsage.start_date
+    return this.data.start_date
   }
 
   get endDate() {
-    return this.productUsage.end_date
+    return this.data.end_date
   }
 
   addTransaction(transaction) {

--- a/src/components/billingRecord/IFXBillingRecordDetail.vue
+++ b/src/components/billingRecord/IFXBillingRecordDetail.vue
@@ -254,6 +254,22 @@ export default {
       </v-row>
       <v-row justify="start" align="center" dense>
         <v-col sm="2">
+          <h3>Start date</h3>
+        </v-col>
+        <v-col>
+          {{ item.startDate }}
+        </v-col>
+      </v-row>
+      <v-row v-if="item.endDate" justify="start" align="center" dense>
+        <v-col sm="2">
+          <h3>End date</h3>
+        </v-col>
+        <v-col>
+          {{ item.endDate }}
+        </v-col>
+      </v-row>
+      <v-row justify="start" align="center" dense>
+        <v-col sm="2">
           <h3>Description</h3>
         </v-col>
         <v-col>

--- a/src/components/billingRecord/IFXBillingRecordDetail.vue
+++ b/src/components/billingRecord/IFXBillingRecordDetail.vue
@@ -276,6 +276,14 @@ export default {
           {{ item.description }}
         </v-col>
       </v-row>
+      <v-row v-if="item.productUsageLinkText" justify="start" align="center" dense>
+        <v-col sm="2">
+          <h3>Usage</h3>
+        </v-col>
+        <v-col>
+          <a :href="item.productUsageUrl">{{ item.productUsageLinkText }}</a>
+        </v-col>
+      </v-row>
       <v-row justify="start" align="center" dense>
         <v-col sm="2">
           <h3>State</h3>

--- a/src/components/billingRecord/IFXBillingRecordDetail.vue
+++ b/src/components/billingRecord/IFXBillingRecordDetail.vue
@@ -257,7 +257,7 @@ export default {
           <h3>Start date</h3>
         </v-col>
         <v-col>
-          {{ item.startDate }}
+          {{ item.startDate | humanDatetime }}
         </v-col>
       </v-row>
       <v-row v-if="item.endDate" justify="start" align="center" dense>
@@ -265,7 +265,7 @@ export default {
           <h3>End date</h3>
         </v-col>
         <v-col>
-          {{ item.endDate }}
+          {{ item.endDate | humanDatetime }}
         </v-col>
       </v-row>
       <v-row justify="start" align="center" dense>

--- a/src/components/billingRecord/IFXBillingRecordListDecimal.vue
+++ b/src/components/billingRecord/IFXBillingRecordListDecimal.vue
@@ -783,7 +783,7 @@ export default {
                 <v-progress-circular indeterminate color="primary"></v-progress-circular>
               </v-col>
               <v-col v-else>
-                <v-row dense class="d-flex justify-space-between align-center">
+                <v-row dense class="d-flex justify-start align-center">
                   <v-col class="pa-2">
                     <IFXMailButton
                       v-if="useDefaultMailButton"


### PR DESCRIPTION
Add product usage links and start and end dates to billing record detail
Ensure that billing record start and end dates come from the billing record, not product usage