### PR TITLE
Don't allow rate editing or deleting on the Product Edit page.

### DIFF
--- a/src/components/item/IFXItemSelectList.vue
+++ b/src/components/item/IFXItemSelectList.vue
@@ -5,24 +5,29 @@ export default {
     title: {
       type: String,
       required: false,
-      default: () => 'Items'
+      default: () => 'Items',
     },
     items: {
       type: Array,
       required: false,
-      default: () => []
+      default: () => [],
     },
     // Function for creating an empty item, usually an empty version of the item type itself
     getEmptyItem: {
       type: Function,
       required: false,
-      default: () => () => null
+      default: () => () => null,
     },
     disabled: {
       type: Boolean,
       required: false,
-      default: false
-    }
+      default: false,
+    },
+    noItemsString: {
+      type: String,
+      required: false,
+      default: () => `There are no ${this.title.toLowerCase()}.`,
+    },
   },
   data() {
     return {
@@ -46,7 +51,7 @@ export default {
     },
     checkValidForm() {
       this.$emit('check-valid-form')
-    }
+    },
   },
   computed: {
     itemsLocal: {
@@ -55,8 +60,8 @@ export default {
       },
       set(items) {
         this.$emit('update:items', items)
-      }
-    }
+      },
+    },
   },
 }
 </script>
@@ -64,14 +69,26 @@ export default {
 <template>
   <div class="data-ctr">
     <div class="data-header-active">
-      <div class="data-title">{{title}}</div>
-      <IFXButton class='add-btn' xSmall v-if='!disabled' :disabled='!canEdit' @action='addItem' btnType='add'></IFXButton>
+      <div class="data-title">{{ title }}</div>
+      <IFXButton
+        class="add-btn"
+        xSmall
+        v-if="!disabled"
+        :disabled="!canEdit"
+        @action="addItem"
+        btnType="add"
+      ></IFXButton>
     </div>
-    <div v-if="!itemsLocal.length" class="items-warning">
-      There are no {{title.toLowerCase()}}.
-    </div>
+    <div v-if="!itemsLocal.length" class="items-warning">{{ noItemsString }}</div>
     <v-card :key="item.id" v-for="(item, index) in itemsLocal" class="data-card">
-      <IFXButton class='delete-btn' v-if='!disabled' :disabled='!canEdit' xSmall @action='removeItem(index)' btnType='remove'></IFXButton>
+      <IFXButton
+        class="delete-btn"
+        v-if="!disabled"
+        :disabled="!canEdit"
+        xSmall
+        @action="removeItem(index)"
+        btnType="remove"
+      ></IFXButton>
       <!-- TODO: Notice that there is no updateItem handler passed in - this means the item prop is being mutated directly in child -->
       <!-- NOTE: this slot occurs in a for loop, i.e. a new slot is being generated for each item instance -->
       <slot :item="item"></slot>

--- a/src/components/item/IFXItemSelectList.vue
+++ b/src/components/item/IFXItemSelectList.vue
@@ -26,7 +26,6 @@ export default {
     noItemsString: {
       type: String,
       required: false,
-      default: () => `There are no ${this.title.toLowerCase()}.`,
     },
   },
   data() {
@@ -54,6 +53,9 @@ export default {
     },
   },
   computed: {
+    noItemsText() {
+      return this.noItemsString !== undefined ? this.noItemsString : `There are no ${this.title.toLowerCase()}.`
+    },
     itemsLocal: {
       get() {
         return this.items
@@ -79,7 +81,7 @@ export default {
         btnType="add"
       ></IFXButton>
     </div>
-    <div v-if="!itemsLocal.length" class="items-warning">{{ noItemsString }}</div>
+    <div v-if="!itemsLocal.length" class="items-warning">{{ noItemsText }}</div>
     <v-card :key="item.id" v-for="(item, index) in itemsLocal" class="data-card">
       <IFXButton
         class="delete-btn"

--- a/src/components/product/IFXProductCreateEdit.vue
+++ b/src/components/product/IFXProductCreateEdit.vue
@@ -44,11 +44,6 @@ export default {
       return `Price per ${item.units ? `${item.units}` : 'unit'} in dollars`
     },
     submit() {
-      // Remove the orginal active state
-      this.item.rates.forEach((rate) => {
-        // eslint-disable-next-line no-param-reassign
-        delete rate.originalActive
-      })
       // Append any new rates to the end
       this.item.rates = this.item.rates.concat(this.newRates)
       if (this.isEditing) this.submitUpdate()

--- a/src/components/product/IFXProductCreateEdit.vue
+++ b/src/components/product/IFXProductCreateEdit.vue
@@ -217,7 +217,7 @@ export default {
               :items="filteredRates"
               :headers="headers"
               :selected.sync="selected"
-              itemType="ProductRate"
+              :itemType="itemType"
               :showSelect="false"
             >
               <template #active="{ item }">

--- a/src/components/product/IFXProductDetail.vue
+++ b/src/components/product/IFXProductDetail.vue
@@ -95,7 +95,18 @@ export default {
             :showSelect="false"
           >
             <template #active="{ item }">
-              {{ item.active ? 'Yes' : 'No' }}
+              <v-tooltip v-if="item.active" top>
+                <template v-slot:activator="{ on, attrs }">
+                  <v-icon v-on="on" v-bind="attrs" color="#fcbd01">lightbulb</v-icon>
+                </template>
+                <span>Active rate</span>
+              </v-tooltip>
+              <v-tooltip v-else top>
+                <template v-slot:activator="{ on, attrs }">
+                  <v-icon v-on="on" v-bind="attrs" color="#ccc">lightbulb</v-icon>
+                </template>
+                <span>Inactive rate</span>
+              </v-tooltip>
             </template>
             <template #maxQty="{ item }">
               {{ item.maxQty ? `${pluralize(item.maxQty, item.units)}` : '∞' }}

--- a/src/components/product/IFXProductDetail.vue
+++ b/src/components/product/IFXProductDetail.vue
@@ -12,6 +12,7 @@ export default {
   data() {
     return {
       selected: [],
+      showDeactivatedRates: false,
     }
   },
   computed: {
@@ -24,6 +25,12 @@ export default {
         { text: 'Active', value: 'active', sortable: true, namedSlot: true },
       ]
       return headers.filter((h) => !h.hide || !this.$vuetify.breakpoint[h.hide])
+    },
+    filteredRates() {
+      if (this.item?.rates) {
+        return this.item.rates.filter((r) => r.active || this.showDeactivatedRates)
+      }
+      return []
     },
   },
   methods: {
@@ -70,10 +77,18 @@ export default {
       </v-row>
       <v-row>
         <v-col>
-          <h3>Rates</h3>
+          <div class="d-flex justify-space-between">
+            <h3>Rates</h3>
+            <v-checkbox
+              class="pt-0 mt-0"
+              v-model="showDeactivatedRates"
+              label="Show deactivated rates"
+              data-cy="show-deactivated-rates"
+            ></v-checkbox>
+          </div>
           <IFXItemDataTable
-            v-if="item.rates && item.rates.length"
-            :items="item.rates"
+            v-if="filteredRates.length"
+            :items="filteredRates"
             :headers="headers"
             :selected.sync="selected"
             itemType="ProductRate"

--- a/src/components/product/IFXProductList.vue
+++ b/src/components/product/IFXProductList.vue
@@ -28,7 +28,13 @@ export default {
   },
   methods: {
     displayRateNames(item) {
-      return item.rates.length ? item.rates.map((rate) => rate.name).join(', ') : 'None'
+      // Only display names for active rates
+      return item.rates.length
+        ? item.rates
+          .filter((rate) => rate.active)
+          .map((rate) => rate.name)
+          .join(', ')
+        : 'None'
     },
   },
 }


### PR DESCRIPTION
This PR changes how rates are displayed and added on the Product Edit page. Since rates are no longer editable or deleteable, showing them in an `IFXItemSelectList` doesn't make sense. So they are now shown in an `IFXItemDataTable` but the `IFXItemSelectList` is still used to create new rates, which can be deleted/edited until the page is saved.

Existing rates can be deactivated and a checkbox is added to allow showing deactivated rates; the default is to not show them.
