### PR TITLE
Only show update button if the rate is `active`

### DIFF
--- a/src/components/product/IFXProductCreateEdit.vue
+++ b/src/components/product/IFXProductCreateEdit.vue
@@ -245,7 +245,7 @@ export default {
               </template>
               <template #actions="{ item }">
                 <IFXButton
-                  v-if="canUpdateRate()"
+                  v-if="item.active && canUpdateRate()"
                   btnType="other"
                   x-small
                   data-cy="update-rate"


### PR DESCRIPTION
Deactivated rates cannot be "updated."