### PR TITLE
Add Run a Report dialog to Report List page

### DIFF
--- a/src/api/IFXAPI.js
+++ b/src/api/IFXAPI.js
@@ -803,7 +803,12 @@ export default class IFXAPIService {
     const baseUrl = this.urls.FACILITIES
     const api = this.genericAPI(baseUrl, Facility)
     api.isDecimalFacility = (facility_name) => {
-      const result = ['Research Computing Storage', 'Center for Brain Science Neuroimaging', 'Harvard University Helium', 'Liquid Nitrogen Service'].includes(facility_name)
+      const result = [
+        'Research Computing Storage',
+        'Center for Brain Science Neuroimaging',
+        'Harvard University Helium',
+        'Liquid Nitrogen Service',
+      ].includes(facility_name)
       return result
     }
     api.isFacilityWithDates = (facility_name) => {

--- a/src/api/IFXAPI.js
+++ b/src/api/IFXAPI.js
@@ -16,7 +16,7 @@ import ProductAccount from '@/components/account/IFXProductAccount'
 import Facility from '@/components/facility/IFXFacility'
 import BillingRecord, { BillingTransaction } from '@/components/billingRecord/IFXBillingRecord'
 import { Product, ProductRate, ProductUsage, Processing } from '@/components/product/IFXProduct'
-import { ReportRun } from '@/components/report/IFXReport'
+import { ReportRun, Report } from '@/components/report/IFXReport'
 
 function isNumeric(val) {
   return !Number.isNaN(parseFloat(val)) && Number.isFinite(val)
@@ -881,6 +881,16 @@ export default class IFXAPIService {
   get reportRun() {
     const baseURL = `${this.urls.REPORT_RUNS}`
     return this.genericAPI(baseURL, ReportRun)
+  }
+
+  get report() {
+    const baseURL = `${this.urls.REPORTS}`
+    const api = this.genericAPI(baseURL, Report)
+    api.runReport = (params) => {
+      const runReportURL = `${this.urls.RUN_REPORT}`
+      return this.axios.post(runReportURL, params, { headers: { 'Content-Type': 'application/json' } })
+    }
+    return api
   }
 
   mockError(code) {

--- a/src/components/calendar/IFXCalendarList.vue
+++ b/src/components/calendar/IFXCalendarList.vue
@@ -1138,7 +1138,7 @@ export default {
                     :items="allowedExpenseCodes"
                     v-model="expenseCode"
                     :rules="[isBillableRule]"
-                    :disabled="cantBeEdited || resourceNotSelected || !expenseCodeEnabled"
+                    :disabled="resourceNotSelected || !expenseCodeEnabled"
                     data-cy="expense-code"
                   >
                     <template #no-data>

--- a/src/components/report/IFXReport.js
+++ b/src/components/report/IFXReport.js
@@ -1,5 +1,10 @@
 import IFXItemBase from '@/components/item/IFXItemBase'
 
+class Report extends IFXItemBase {
+  get name() {
+    return this.data.name
+  }
+}
 class ReportRun extends IFXItemBase {
   get report() {
     return this.data.report
@@ -29,4 +34,4 @@ class ReportRun extends IFXItemBase {
     return this.data.updated
   }
 }
-export { ReportRun }
+export { ReportRun, Report }

--- a/src/components/report/IFXReportRunList.vue
+++ b/src/components/report/IFXReportRunList.vue
@@ -194,6 +194,7 @@ export default {
                   </template>
                   <v-date-picker
                     :max="currentMonth"
+                    :min="endMonth"
                     v-model="startMonth"
                     type="month"
                     @input="startDateMenu = false"
@@ -248,14 +249,6 @@ export default {
               Running {{ selectedReport.name }}...
               <v-progress-linear indeterminate></v-progress-linear>
             </div>
-            <!-- <v-row no-gutters v-if="reportResponse && reportResponse.id">
-              <v-col cols="12" class="text-body-1 mt-2">
-                <div class="text-body-1 font-weight-medium text-center">{{ selectedReport.name }} Report Results</div>
-                <div class="text-body-1 mt-1">
-                  Report id {{ reportResponse.id }} completed at {{ reportResponse.updated | humanDatetime }}
-                </div>
-              </v-col>
-            </v-row> -->
           </v-form>
         </v-card-text>
         <v-card-actions>

--- a/src/components/report/IFXReportRunList.vue
+++ b/src/components/report/IFXReportRunList.vue
@@ -14,7 +14,7 @@ export default {
   },
   data() {
     return {
-      reportTypes: [],
+      reports: [],
       showReportDialog: false,
       startMonth: '',
       endMonth: '',
@@ -42,6 +42,22 @@ export default {
   },
   methods: {
     ...mapActions(['showMessage']),
+    getRootUrl() {
+      // If ROOT_URL is a thing, clip off the application name at the end because the file url has that already
+      let root_url = this.$api.urls.ROOT_URL
+      if (root_url) {
+        root_url = root_url.replace(/\/[^/]+\/$/, '')
+      }
+      return root_url
+    },
+    getXlsUrl(item) {
+      const root_url = this.getRootUrl()
+      return `${root_url}${item.xlsFileUrl}`
+    },
+    getTextUrl(item) {
+      const root_url = this.getRootUrl()
+      return `${root_url}${item.textFileUrl}`
+    },
     getSetItems() {
       return (
         this.apiRef
@@ -50,10 +66,10 @@ export default {
             this.items = items
             // Get all available reports
             this.$api.report.getList().then((reports) => {
-              this.reportTypes = Array.from(reports)
-              if (this.reportTypes.length === 1) {
+              this.reports = Array.from(reports)
+              if (this.reports.length === 1) {
                 // If only one report, preload it
-                this.selectedReport = this.reportTypes[0]
+                this.selectedReport = this.reports[0]
               }
             })
           })
@@ -125,7 +141,7 @@ export default {
             <v-tooltip top>
               <template v-slot:activator="{ on, attrs }">
                 <div v-on="on">
-                  <v-btn v-if="reportTypes.length" v-bind="attrs" fab small color="green" @click="openReportDialog()">
+                  <v-btn v-if="reports.length" v-bind="attrs" fab small color="green" @click="openReportDialog()">
                     <v-icon dark>mdi-text-box-plus-outline</v-icon>
                   </v-btn>
                 </div>
@@ -138,10 +154,10 @@ export default {
     </IFXPageHeader>
     <IFXItemDataTable :items="filteredItems" :headers="headers" :selected.sync="selected" :itemType="itemType">
       <template #xlsFilePath="{ item }">
-        <a :href="item.xlsFileUrl">{{ item.xlsFilePath }}</a>
+        <a :href="getXlsUrl(item)">{{ item.xlsFilePath }}</a>
       </template>
       <template #textFilePath="{ item }">
-        <a :href="item.textFileUrl">{{ item.textFilePath }}</a>
+        <a :href="getTextUrl(item)">{{ item.textFilePath }}</a>
       </template>
       <template #updated="{ item }">
         {{ item.updated | humanDatetime }}
@@ -158,7 +174,7 @@ export default {
               <v-col align="center">
                 <v-autocomplete
                   v-model="selectedReport"
-                  :items="reportTypes"
+                  :items="reports"
                   item-text="name"
                   item-value="id"
                   label="Select Report"

--- a/src/components/report/IFXReportRunList.vue
+++ b/src/components/report/IFXReportRunList.vue
@@ -1,4 +1,5 @@
 <script>
+import { mapActions } from 'vuex'
 import IFXSearchField from '@/components/IFXSearchField'
 import IFXItemDataTable from '@/components/item/IFXItemDataTable'
 import IFXItemListMixin from '@/components/item/IFXItemListMixin'
@@ -10,6 +11,22 @@ export default {
   components: {
     IFXSearchField,
     IFXItemDataTable,
+  },
+  data() {
+    return {
+      reportTypes: [],
+      showReportDialog: false,
+      startMonth: '',
+      endMonth: '',
+      dateMenu: false,
+      startDateMenu: false,
+      endDateMenu: false,
+      useFiscalYear: false,
+      selectedReport: {},
+      reportRunning: false,
+      reportResponse: null,
+      currentMonth: new Date().toISOString(),
+    }
   },
   computed: {
     headers() {
@@ -23,6 +40,77 @@ export default {
       return headers.filter((h) => !h.hide || !this.$vuetify.breakpoint[h.hide])
     },
   },
+  methods: {
+    ...mapActions(['showMessage']),
+    getSetItems() {
+      return (
+        this.apiRef
+          .getList()
+          .then((items) => {
+            this.items = items
+            // Get all available reports
+            this.$api.report.getList().then((reports) => {
+              this.reportTypes = Array.from(reports)
+              if (this.reportTypes.length === 1) {
+                // If only one report, preload it
+                this.selectedReport = this.reportTypes[0]
+              }
+            })
+          })
+          // TODO: work on handling this error
+          .catch((error) => {
+            this.showMessage(error)
+            this.rtr.replace({ name: 'Home' })
+          })
+      )
+    },
+    openReportDialog() {
+      this.showReportDialog = true
+    },
+    closeReportDialog() {
+      this.showReportDialog = false
+      this.reportRunning = false
+      this.reportResponse = {}
+      this.useFiscalYear = false
+    },
+    async runSelectedReport() {
+      this.reportRunning = true
+      // build params
+      const monthRange = this.endMonth ? `${this.startMonth}:${this.endMonth}` : this.startMonth
+      const params = {
+        date_range: this.useFiscalYear ? 'fy' : monthRange,
+        name: this.selectedReport.name,
+      }
+      try {
+        const res = await this.$api.report.runReport(params)
+        this.reportResponse = this.$api.reportRun.create(res.data)
+        if (this.reportResponse?.id) {
+          // Check if this is an existing report
+          const index = this.items.findIndex((item) => item.id === this.reportResponse.id)
+          if (index !== -1) {
+            // Replace the old report info with the new info, which will be the time the report was run.
+            this.items.splice(index, 1, this.reportResponse)
+          } else {
+            // A new report so add it to the list
+            this.items.push(this.reportResponse)
+          }
+          const updatedTime = this.$options.filters.humanDatetime(this.reportResponse.updated)
+          const msg = `Report id ${this.reportResponse.id} completed at ${updatedTime}`
+          this.showMessage(msg)
+          this.closeReportDialog()
+        }
+      } catch (err) {
+        this.showMessage(err)
+      } finally {
+        this.reportRunning = false
+      }
+    },
+    toggleFiscalYear() {
+      // Close any open menus
+      this.startDateMenu = false
+      this.endDateMenu = false
+    },
+  },
 }
 </script>
 
@@ -31,7 +119,21 @@ export default {
     <IFXPageHeader>
       <template #title>{{ listTitle }}</template>
       <template #actions>
-        <IFXSearchField :search.sync="search" />
+        <v-row class="flex-nowrap">
+          <v-col><IFXSearchField :search.sync="search" /></v-col>
+          <v-col sm="2">
+            <v-tooltip top>
+              <template v-slot:activator="{ on, attrs }">
+                <div v-on="on">
+                  <v-btn v-if="reportTypes.length" v-bind="attrs" fab small color="green" @click="openReportDialog()">
+                    <v-icon dark>mdi-text-box-plus-outline</v-icon>
+                  </v-btn>
+                </div>
+              </template>
+              <span>Run a report</span>
+            </v-tooltip>
+          </v-col>
+        </v-row>
       </template>
     </IFXPageHeader>
     <IFXItemDataTable :items="filteredItems" :headers="headers" :selected.sync="selected" :itemType="itemType">
@@ -45,5 +147,147 @@ export default {
         {{ item.updated | humanDatetime }}
       </template>
     </IFXItemDataTable>
+    <v-dialog v-bind="attrs" v-if="showReportDialog" v-model="showReportDialog" max-width="600px">
+      <v-card>
+        <v-card-title>
+          <span class="text-h5">Run a report</span>
+        </v-card-title>
+        <v-card-text>
+          <v-form v-model="isValid">
+            <v-row class="text-body-1">
+              <v-col align="center">
+                <v-autocomplete
+                  v-model="selectedReport"
+                  :items="reportTypes"
+                  item-text="name"
+                  item-value="id"
+                  label="Select Report"
+                  :rules="formRules.generic"
+                  return-object
+                  required
+                ></v-autocomplete>
+              </v-col>
+            </v-row>
+            <div class="text-body-1 mb-0 mt-2">Select starting and ending months</div>
+            <v-row class="text-body-1">
+              <v-col cols="6">
+                <v-menu
+                  v-model="startDateMenu"
+                  :close-on-content-click="false"
+                  :nudge-right="40"
+                  transition="scale-transition"
+                  offset-y
+                  min-width="auto"
+                >
+                  <template v-slot:activator="{ on, attrs }">
+                    <v-text-field
+                      :disabled="useFiscalYear"
+                      v-model="startMonth"
+                      label="Start Month"
+                      prepend-icon="mdi-calendar"
+                      readonly
+                      v-bind="attrs"
+                      v-on="on"
+                      hint="YYYY-MM format"
+                      persistent-hint
+                    ></v-text-field>
+                  </template>
+                  <v-date-picker
+                    :max="currentMonth"
+                    v-model="startMonth"
+                    type="month"
+                    @input="startDateMenu = false"
+                  ></v-date-picker>
+                </v-menu>
+              </v-col>
+              <v-col cols="6">
+                <v-menu
+                  v-model="endMonthMenu"
+                  :close-on-content-click="false"
+                  :nudge-right="40"
+                  transition="scale-transition"
+                  offset-y
+                  min-width="auto"
+                >
+                  <template v-slot:activator="{ on, attrs }">
+                    <v-text-field
+                      :disabled="useFiscalYear"
+                      v-model="endMonth"
+                      label="End Month (optional)"
+                      prepend-icon="mdi-calendar"
+                      clear-icon="mdi-close-circle"
+                      clearable
+                      readonly
+                      v-bind="attrs"
+                      v-on="on"
+                      hint="YYYY-MM format"
+                      persistent-hint
+                    ></v-text-field>
+                  </template>
+                  <v-date-picker
+                    :min="startMonth"
+                    :max="currentMonth"
+                    v-model="endMonth"
+                    type="month"
+                    @input="endMonthMenu = false"
+                  ></v-date-picker>
+                </v-menu>
+              </v-col>
+            </v-row>
+            <v-row class="text-body-1">
+              <v-col>
+                <div class="text-divider font-italic text-center">or</div>
+                <v-checkbox
+                  v-model="useFiscalYear"
+                  label="Use current fiscal year"
+                  @click="toggleFiscalYear()"
+                ></v-checkbox>
+              </v-col>
+            </v-row>
+            <div v-if="reportRunning">
+              Running {{ selectedReport.name }}...
+              <v-progress-linear indeterminate></v-progress-linear>
+            </div>
+            <!-- <v-row no-gutters v-if="reportResponse && reportResponse.id">
+              <v-col cols="12" class="text-body-1 mt-2">
+                <div class="text-body-1 font-weight-medium text-center">{{ selectedReport.name }} Report Results</div>
+                <div class="text-body-1 mt-1">
+                  Report id {{ reportResponse.id }} completed at {{ reportResponse.updated | humanDatetime }}
+                </div>
+              </v-col>
+            </v-row> -->
+          </v-form>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn color="secondary" text @click="closeReportDialog">Cancel</v-btn>
+          <v-btn color="blue darken-1" text :disabled="!isValid" @click="runSelectedReport">Run</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
   </v-container>
 </template>
+<style lang="scss" scoped>
+.text-divider {
+  display: flex;
+  align-items: center;
+  letter-spacing: 0.1em;
+  --text-divider-gap: 1rem;
+
+  &::before,
+  &::after {
+    content: '';
+    height: 1px;
+    background-color: silver;
+    flex-grow: 1;
+  }
+
+  &::before {
+    margin-right: var(--text-divider-gap);
+  }
+
+  &::after {
+    margin-left: var(--text-divider-gap);
+  }
+}
+</style>


### PR DESCRIPTION
This MR adds a dialog that allows the user to run selected reports against various year/months or the current fiscal year. This dialog is reached from the Report List page and will prompt the user for which report they with to run as well as which year/months to start and end the report. The user can also just check a box to use the current fiscal year which will disable the year/month selectors.

Once the user clicks `run`, a spinner shows that the report is running. Once it finishes, a toast is displayed to let the user know the report done. It either replaces an existing report if the `id` matches (the `updated` time will change) or is added to the end of the list as a new report.