### PR TITLE
More accessibility fixes

### DIFF
--- a/src/components/page/IFXPageHeader.vue
+++ b/src/components/page/IFXPageHeader.vue
@@ -61,7 +61,6 @@ export default {
     },
     hasID() {
       // Only show id H1 if the slot has something in it (for accessibility)
-      console.log(this.$slots, this.$scopedSlots)
       return !!this.$scopedSlots.id
     },
   },
@@ -82,7 +81,7 @@ export default {
       <v-row v-if="hasTitle" justify="space-between" align="center" class="my-0">
         <div class="title-ctr">
           <h1 data-cy="header-title" :class="headerClass"><slot name="title"></slot></h1>
-          <h1 v-if="hasID" data-cy="header-id"><slot name="id"></slot></h1>
+          <h1 v-if="hasID" data-cy="header-id" :class="headerClass"><slot name="id"></slot></h1>
           <span data-cy="header-id" class="d-none"><slot name="cypress"></slot></span>
         </div>
         <div class="actions-ctr" :class="actionsContainerClass">

--- a/src/sass/variables.scss
+++ b/src/sass/variables.scss
@@ -8,16 +8,16 @@ $font-size-root: 14px;
 $btn-letter-spacing: 0;
 $btn-font-weight: 400;
 $btn-sizes: (
-  "default": 38,
-  "large": 51,
+  'default': 38,
+  'large': 51,
 );
 $fab-sizes: (
-  "default": 54,
-  "large": 62,
+  'default': 54,
+  'large': 62,
 );
 $fab-icon-sizes: (
-  "small": 20,
-  "default": 22,
+  'small': 20,
+  'default': 22,
 );
 
 $list-item-title-font-size: 0.929rem;
@@ -30,40 +30,40 @@ $list-item-icon-margin: 8px;
 
 //Rewrite all the headings
 $headings: (
-  "h1": (
-    "size": 3.3125rem,
-    "line-height": 1.15em,
+  'h1': (
+    'size': 3.3125rem,
+    'line-height': 1.15em,
   ),
-  "h2": (
-    "size": 2.25rem,
-    "line-height": 1.5em,
+  'h2': (
+    'size': 2.25rem,
+    'line-height': 1.5em,
   ),
-  "h3": (
-    "size": 1.9rem,
-    "line-height": 1.2em,
+  'h3': (
+    'size': 1.9rem,
+    'line-height': 1.2em,
   ),
 );
 
 $icon-sizes: (
-  "x-small": (
-    "font-size": 8,
-    "height": 14,
+  'x-small': (
+    'font-size': 8,
+    'height': 14,
   ),
-  "small": (
-    "font-size": 10,
-    "height": 22,
+  'small': (
+    'font-size': 10,
+    'height': 22,
   ),
-  "default": (
-    "font-size": 12,
-    "height": 30,
+  'default': (
+    'font-size': 12,
+    'height': 30,
   ),
-  "large": (
-    "font-size": 14,
-    "height": 52,
+  'large': (
+    'font-size': 14,
+    'height': 52,
   ),
-  "x-large": (
-    "font-size": 16,
-    "height": 64,
+  'x-large': (
+    'font-size': 16,
+    'height': 64,
   ),
 );
 
@@ -71,4 +71,9 @@ $icon-sizes: (
   font-size: 14px;
 }
 
-@import "~vuetify/src/styles/styles.sass";
+.text-label {
+  font-size: 1.17em;
+  font-weight: bold;
+}
+
+@import '~vuetify/src/styles/styles.sass';


### PR DESCRIPTION
This PR fixes some more accessibility issues by adding a global `text-label` class that has the same font styles as a bare `H3` tag. Since we often use `H3` tags in detail pages, these can be changed to `div` with the `text-label` class applied. 

Also remove a leftover `console.log` and add back in some header classes in the `id` slot in `IFXPageHeader`
