### PR TITLE
Accessibility fixes part 3

### DIFF
--- a/src/components/IFXSearchField.vue
+++ b/src/components/IFXSearchField.vue
@@ -1,15 +1,15 @@
 <template>
   <v-text-field
     v-model="searchLocal"
-    class='search-field'
-    :label='label'
+    class="search-field"
+    :label="label"
+    :aria-label="ariaLabel"
     single-line
     hide-details
-    :clearable='clearable'
+    :clearable="clearable"
     :disabled="disabled"
-    data-cy='ifx-search-field'
-  >
-  </v-text-field>
+    data-cy="ifx-search-field"
+  ></v-text-field>
 </template>
 
 <script>
@@ -20,23 +20,23 @@ export default {
     search: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
     label: {
       type: String,
       required: false,
-      default: 'Search'
+      default: 'Search',
     },
     disabled: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
     clearable: {
       type: Boolean,
       required: false,
-      default: true
-    }
+      default: true,
+    },
   },
   computed: {
     searchLocal: {
@@ -45,15 +45,18 @@ export default {
       },
       set(search) {
         this.$emit('update:search', search)
-      }
-    }
-  }
+      },
+    },
+    ariaLabel() {
+      return this.label ? this.label : 'Filter List'
+    },
+  },
 }
 </script>
 
 <style scoped>
-  .search-field {
-    width: 350px;
-    display: inline-block !important;
-  }
+.search-field {
+  width: 350px;
+  display: inline-block !important;
+}
 </style>

--- a/src/components/calendar/IFXCalendarList.vue
+++ b/src/components/calendar/IFXCalendarList.vue
@@ -1728,4 +1728,19 @@ export default {
     margin-left: 0;
   }
 }
+.theme--light.v-calendar-weekly {
+  .v-calendar-weekly__head-weekday[role='columnheader'] {
+    &.v-past {
+      color: #767676;
+      &.v-outside {
+        color: #717171;
+      }
+    }
+    &.v-present {
+      &.primary--text {
+        color: #1f80a1;
+      }
+    }
+  }
+}
 </style>

--- a/src/components/calendar/IFXCalendarList.vue
+++ b/src/components/calendar/IFXCalendarList.vue
@@ -1738,7 +1738,21 @@ export default {
     }
     &.v-present {
       &.primary--text {
-        color: #1f80a1;
+        color: #1f80a1 !important;
+      }
+    }
+  }
+}
+.theme--light.v-calendar-daily {
+  .v-calendar-daily_head-day {
+    &.v-past {
+      .v-calendar-daily_head-weekday {
+        color: #767676 !important;
+      }
+    }
+    &.v-present {
+      .v-calendar-daily_head-weekday.primary--text {
+        color: #1f80a1 !important;
       }
     }
   }

--- a/src/components/calendar/IFXCalendarList.vue
+++ b/src/components/calendar/IFXCalendarList.vue
@@ -1211,7 +1211,7 @@ export default {
                   </v-menu>
                   <v-row>
                     <v-col>
-                      <v-select
+                      <v-autocomplete
                         label="Length of reservation"
                         v-model="durationValue"
                         :items="duration"
@@ -1223,7 +1223,7 @@ export default {
                         <template #no-data>
                           <div class="mx-3 my-1">No options (you must select a resource)</div>
                         </template>
-                      </v-select>
+                      </v-autocomplete>
                     </v-col>
                   </v-row>
                   <v-row>

--- a/src/components/item/IFXItemDataTable.vue
+++ b/src/components/item/IFXItemDataTable.vue
@@ -162,6 +162,10 @@ export default {
       <span class="grey--text text--darken-1">No data available</span>
     </template>
 
+    <template #loading>
+      <span class="grey--text text--darken-1">Loading items...</span>
+    </template>
+
     <template v-for="header in headers" #[`item.${header.value}`]="{ item }">
       <span v-if="header.namedSlot" v-bind:key="header.value">
         <slot :name="header.value" :item="item"></slot>

--- a/src/components/item/IFXItemDataTable.vue
+++ b/src/components/item/IFXItemDataTable.vue
@@ -154,8 +154,12 @@ export default {
 
     <template #header.rowActionDetailEdit="{ header }">
       <span class="d-sr-only" v-bind:key="header.value">
-        Buttons to go to the editable Detail page for the item in each row"
+        Buttons to go to the editable Detail page for the item in each row
       </span>
+    </template>
+
+    <template #no-data>
+      <span class="grey--text text--darken-1">No data available</span>
     </template>
 
     <template v-for="header in headers" #[`item.${header.value}`]="{ item }">


### PR DESCRIPTION
This PR has a few more accessibility fixes including fixing the _no data_ and _loading..._ table text and calendar month and week headers have sufficient contrast as well as using a `v-autocomplete` instead of a `v-select` for the reservations panel.

It also adds a label to the table search field.
