### PR TITLE
Add facility primary contact role

### DIFF
--- a/src/components/organization/IFXOrganizationDetail.vue
+++ b/src/components/organization/IFXOrganizationDetail.vue
@@ -38,6 +38,7 @@ export default {
       allRoles: [
         { name: 'PI', editable: false },
         { name: 'Lab Manager', editable: false },
+        { name: 'Facility Primary Contact', editable: true },
         { name: 'Facility Invoice', editable: true },
         { name: 'Facility Invoice CC', editable: true },
       ],


### PR DESCRIPTION
This is a super terrible thing to keep doing.  Need some kind of contact roles listing that is either in the database with Django admin support or in settings that can be exposed by the settings view.