### PR TITLE
Fix progress bars

### DIFF
--- a/src/components/calendar/IFXCalendarList.vue
+++ b/src/components/calendar/IFXCalendarList.vue
@@ -997,6 +997,7 @@ export default {
         </v-sheet>
         <v-sheet :min-height="calHeight" class="d-flex justify-middle relative">
           <span class="flex-grow-1">
+            <v-progress-linear v-if="eventsAreLoading" indeterminate></v-progress-linear>
             <v-calendar
               ref="calendar"
               v-model="calModel"
@@ -1044,7 +1045,6 @@ export default {
                 <div class="v-current-time" :class="{ first: date === week[0].date }" :style="{ top: nowY() }"></div>
               </template>
             </v-calendar>
-            <v-progress-linear v-if="eventsAreLoading" indeterminate></v-progress-linear>
           </span>
           <v-expand-x-transition>
             <v-card color="grey lighten-4 ml-4 " min-width="350px" max-width="550px" v-show="reservationOpen">

--- a/src/sass/variables.scss
+++ b/src/sass/variables.scss
@@ -76,4 +76,11 @@ $icon-sizes: (
   font-weight: bold;
 }
 
+// Force progress bars to always animate
+[role='progressbar'] {
+  & .long,
+  & .short {
+    animation-play-state: running !important;
+  }
+}
 @import '~vuetify/src/styles/styles.sass';


### PR DESCRIPTION
This PR adds CSS that should force the `animation-play-state` to `running` to work around a Vuetify 2.5 feature that stopped progress bars if they were hidden. The intersectional observer they use to determine if the progress bar is visible seems to not turn the visibility back on at times. 

Also move the progress bar to the top of the calendar instead of the bottom because it wasn't visible on most screens.