### PR TITLE
Better handle searching of boolean values

### DIFF
--- a/src/components/item/IFXItemListMixin.js
+++ b/src/components/item/IFXItemListMixin.js
@@ -89,7 +89,14 @@ export default {
           if (i.data) {
             item = i.data
           }
-          return Object.keys(item).some((j) => this.filterSearch(item[j], search))
+          return Object.keys(item).some((j) => {
+            let thingToBeSearched = item[j]
+            if (typeof item[j] === 'boolean' && item[j]) {
+              // If this is a boolean and true, search the key name instead
+              thingToBeSearched = j
+            }
+            return this.filterSearch(thingToBeSearched, search)
+          })
         })
       }
       return items

--- a/src/components/item/IFXItemListMixin.js
+++ b/src/components/item/IFXItemListMixin.js
@@ -11,6 +11,7 @@ export default {
       selected: [],
       search: '',
       deepSearch: false,
+      searchBooleans: false,
     }
   },
   methods: {
@@ -91,7 +92,7 @@ export default {
           }
           return Object.keys(item).some((j) => {
             let thingToBeSearched = item[j]
-            if (typeof item[j] === 'boolean' && item[j]) {
+            if (this.searchBooleans && typeof item[j] === 'boolean' && item[j]) {
               // If this is a boolean and true, search the key name instead
               thingToBeSearched = j
             }
@@ -105,7 +106,14 @@ export default {
       let search = s
       if (this.deepSearch && v && typeof v === 'object' && !Array.isArray(v) && v.data) {
         const item = v.data
-        return Object.keys(item).some((j) => this.filterSearch(item[j], search))
+        return Object.keys(item).some((j) => {
+          let thingToBeSearched = item[j]
+          if (this.searchBooleans && typeof item[j] === 'boolean' && item[j]) {
+            // If this is a boolean and true, search the key name instead
+            thingToBeSearched = j
+          }
+          return this.filterSearch(thingToBeSearched, search)
+        })
       }
       if (search && v) {
         let val = v.toString().toLowerCase()
@@ -116,7 +124,7 @@ export default {
         if (Number.parseFloat(search)) {
           search = search.replace('.', '')
         }
-        return val !== null && ['undefined', 'boolean'].indexOf(typeof val) === -1 && val.indexOf(search) !== -1
+        return val !== null && ['undefined', 'boolean'].indexOf(typeof v) === -1 && val.indexOf(search) !== -1
       }
       return false
     },


### PR DESCRIPTION
This PR adds an option to allow our internal search to search `boolean` values. It does this by checking if the element of an object is both `typeof` `boolean` and `true`; if so, it checks the name of the element rather than its value (`true`).

To enable this, set `searchBooleans` to `true` in any page using `IFXItemListMixin.js`