### PR TITLE
Fix billing record summary

### DIFF
--- a/src/components/billingRecord/IFXBillingRecordList.vue
+++ b/src/components/billingRecord/IFXBillingRecordList.vue
@@ -445,7 +445,7 @@ export default {
     },
     summaryCharges(group) {
       const records = this.filteredItems.filter((item) => item.account.organization === group)
-      const summary = records.reduce((prev, current) => prev + parseInt(current.decimalCharge, 10), 0)
+      const summary = records.reduce((prev, current) => prev + parseInt(current.charge, 10), 0)
       return summary
     },
     getSummaryDetails(group) {

--- a/src/components/billingRecord/IFXBillingRecordListDecimal.vue
+++ b/src/components/billingRecord/IFXBillingRecordListDecimal.vue
@@ -447,7 +447,7 @@ export default {
     },
     summaryCharges(group) {
       const records = this.filteredItems.filter((item) => item.account.organization === group)
-      const summary = records.reduce((prev, current) => prev + parseInt(current.decimalCharge, 10), 0)
+      const summary = records.reduce((prev, current) => prev + parseFloat(current.decimalCharge), 0)
       return summary
     },
     getSummaryDetails(group) {


### PR DESCRIPTION
This PR fixes the billing record summary for `IFXBillingRecordListDecimal`; it was using `parseInt` to parse the `decimalCharge` which is floating point, effectively truncating values. This was used in a `reduce` call to sum up the charges for an organization. This mostly showed up in LN2 billing as the amounts are small. 

We're now using `parseFloat` for this.
