### PR TITLE
Export ifxItemEditableDetailMixin

### DIFF
--- a/src/api/IFXAPI.js
+++ b/src/api/IFXAPI.js
@@ -111,8 +111,8 @@ export default class IFXAPIService {
     return {
       // Create and decompose are synchronous - this is important for the more complex apis, like Organization
       // As organization creation is assumed to be sync, so if users, contacts creation is async, things break
-      create: (data) => createFunc(data),
-      decompose: (item) => decomposeFunc(item),
+      create: (data) => createFunc(data, false),
+      decompose: (item) => decomposeFunc(item, true),
       getList: async (params = {}) => this.axios.get(baseURL, { params }).then((res) => res.data.map((item) => createFunc(item))),
       getByID: async (id) => {
         const url = `${baseURL}${id}/`

--- a/src/entrypoint.js
+++ b/src/entrypoint.js
@@ -16,6 +16,7 @@ import IFXPageActionBar from '@/components/page/IFXPageActionBar'
 // Item
 import IFXItemCreateEditMixin from '@/components/item/IFXItemCreateEditMixin'
 import IFXItemDetailMixin from '@/components/item/IFXItemDetailMixin'
+import IFXItemEditableDetailMixin from '@/components/item/IFXItemEditableDetailMixin'
 import IFXItemListMixin from '@/components/item/IFXItemListMixin'
 import IFXItemSelectableMixin from '@/components/item/IFXItemSelectableMixin'
 import IFXItemSelectList from '@/components/item/IFXItemSelectList'
@@ -146,6 +147,7 @@ export {
   IFXItemSelectList,
   IFXItemCreateEditMixin,
   IFXItemDetailMixin,
+  IFXItemEditableDetailMixin,
   IFXItemListMixin,
   IFXItemSelectableMixin,
   IFXItemHistoryDisplay,


### PR DESCRIPTION
This PR exports the `IFXItemEditableDetailMixin` so it can be used by other ifxapps. In this case, it will be used by NICE.

Also, I've added the `decompose` flag to the default IFXAPI.js generic services. This allows the `decomposeFunc` to just call the `createFunc` with `decompose` set to `true`. Note that this can be ignored if you want separate functions.
