### PR TITLE
Add optional footer containing month totals to billing record list display

### DIFF
--- a/src/components/billingRecord/IFXBillingRecord.js
+++ b/src/components/billingRecord/IFXBillingRecord.js
@@ -116,6 +116,14 @@ export default class BillingRecord extends IFXItemBase {
     this.data.decimal_charge = decimalCharge
   }
 
+  get decimalQuantity() {
+    return this.data.decimal_quantity
+  }
+
+  set decimalQuantity(decimalQuantity) {
+    this.data.decimal_quantity = decimalQuantity
+  }
+
   get description() {
     return this.data.description
   }

--- a/src/components/billingRecord/IFXBillingRecordHeader.vue
+++ b/src/components/billingRecord/IFXBillingRecordHeader.vue
@@ -73,7 +73,7 @@ export default {
 }
 </script>
 <template>
-  <td :colspan="colSpan" class="py-2">
+  <td :colspan="colSpan" class="py-4">
     <v-row>
       <v-checkbox
         v-if="showCheckboxes"

--- a/src/components/billingRecord/IFXBillingRecordHeaderDecimal.vue
+++ b/src/components/billingRecord/IFXBillingRecordHeaderDecimal.vue
@@ -73,7 +73,7 @@ export default {
 }
 </script>
 <template>
-  <td :colspan="colSpan" class="py-2">
+  <td :colspan="colSpan" class="py-4">
     <v-row>
       <v-checkbox
         v-if="showCheckboxes"

--- a/src/components/billingRecord/IFXBillingRecordList.vue
+++ b/src/components/billingRecord/IFXBillingRecordList.vue
@@ -81,6 +81,16 @@ export default {
       required: false,
       default: null,
     },
+    showTotals: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+    totalUnits: {
+      type: String,
+      required: false,
+      default: 'hours',
+    },
   },
   mounted() {
     this.facilityBillingRecords()
@@ -461,6 +471,14 @@ export default {
         }
       })
       return expenseMap
+    },
+    totalCharges() {
+      const total = this.filteredItems.reduce((prev, current) => prev + current.charge, 0)
+      return total
+    },
+    totalHours() {
+      const total = this.filteredItems.reduce((prev, current) => prev + current.decimalQuantity, 0)
+      return total
     },
     determineGroupState(e) {
       const group = e.item.account.organization
@@ -1136,6 +1154,14 @@ export default {
             </template>
             <template v-slot:expanded-item="{ item }">
               <IFXBillingRecordTransactions :billingRecord="item" />
+            </template>
+            <template v-slot:footer.prepend v-if="showTotals">
+              <span class="text-body-1">
+                {{ facility.name }} total charges for {{ date }} are
+                <span class="font-weight-medium">{{ totalCharges() | centsToDollars }}</span>
+                for
+                <span class="font-weight-medium">{{ totalHours() }} {{ totalUnits }}</span>
+              </span>
             </template>
           </v-data-table>
           <v-dialog v-model="txnDialog" max-width="600px">

--- a/src/components/billingRecord/IFXBillingRecordListDecimal.vue
+++ b/src/components/billingRecord/IFXBillingRecordListDecimal.vue
@@ -81,6 +81,16 @@ export default {
       required: false,
       default: null,
     },
+    showTotals: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+    totalUnits: {
+      type: String,
+      required: false,
+      default: 'hours',
+    },
   },
   mounted() {
     this.facilityBillingRecords()
@@ -447,7 +457,7 @@ export default {
     },
     summaryCharges(group) {
       const records = this.filteredItems.filter((item) => item.account.organization === group)
-      const summary = records.reduce((prev, current) => prev + parseFloat(current.decimalCharge), 0)
+      const summary = records.reduce((prev, current) => prev + current.decimalCharge, 0)
       return summary
     },
     getSummaryDetails(group) {
@@ -463,6 +473,14 @@ export default {
         }
       })
       return expenseMap
+    },
+    totalCharges() {
+      const total = this.filteredItems.reduce((prev, current) => prev + current.decimalCharge, 0)
+      return total
+    },
+    totalHours() {
+      const total = this.filteredItems.reduce((prev, current) => prev + current.decimalQuantity, 0)
+      return total
     },
     determineGroupState(e) {
       const group = e.item.account.organization
@@ -1134,6 +1152,14 @@ export default {
             </template>
             <template v-slot:expanded-item="{ item }">
               <IFXBillingRecordTransactionsDecimal :billingRecord="item" />
+            </template>
+            <template v-slot:footer.prepend v-if="showTotals">
+              <span class="text-body-1">
+                {{ facility.name }} total charges for {{ date }} are
+                <span class="font-weight-medium">{{ totalCharges() | dollars }}</span>
+                for
+                <span class="font-weight-medium">{{ totalHours() }} {{ totalUnits }}</span>
+              </span>
             </template>
           </v-data-table>
           <v-dialog v-model="txnDialog" max-width="600px">

--- a/src/components/billingRecord/IFXBillingRecords.vue
+++ b/src/components/billingRecord/IFXBillingRecords.vue
@@ -27,6 +27,16 @@ export default {
       required: false,
       default: false,
     },
+    showTotals: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+    totalUnits: {
+      type: String,
+      required: false,
+      default: 'hours',
+    },
   },
   data() {
     return {
@@ -60,12 +70,8 @@ export default {
     getInitialDate() {
       let initialDate = this.$api.storage.getItem('billingRecordListDate', 'session')
       if (!initialDate) {
-        let year = moment()
-          .subtract(1, 'months')
-          .year()
-        let month = moment()
-          .subtract(1, 'months')
-          .format('MM')
+        let year = moment().subtract(1, 'months').year()
+        let month = moment().subtract(1, 'months').format('MM')
         if (this.$route.query.year && /^[0-9]{4}$/.test(this.$route.query.year.trim())) {
           year = this.$route.query.year.trim()
         }
@@ -150,6 +156,8 @@ export default {
             :allowDownloads="allowDownloads"
             :useDefaultMailButton="useDefaultMailButton"
             :showDates="showDates"
+            :showTotals="showTotals"
+            :totalUnits="totalUnits"
           />
           <IFXBillingRecordList
             v-else
@@ -161,6 +169,8 @@ export default {
             :allowDownloads="allowDownloads"
             :useDefaultMailButton="useDefaultMailButton"
             :showDates="showDates"
+            :showTotals="showTotals"
+            :totalUnits="totalUnits"
           />
         </v-col>
       </v-row>


### PR DESCRIPTION
This PR adds an optional footer to the `IFXBillingRecordList` and `IFXBillingRecordListDecimal` components. This footer contains the facility, the month and the total dollars and "units" used that month. Since the units vary for each facility, the text describing the unit is passed in.  The number of units is  always `decimal_quantity`.

There are two new optional props, `showTotals`, defaults to `false`, and `totalUnits`, defaults to `hours`, which is the string displayed for the units.

This will primarily be used for CBSN.
