### PR TITLE
Add buttons to IFXUserList

### DIFF
--- a/src/components/item/IFXItemListMixin.js
+++ b/src/components/item/IFXItemListMixin.js
@@ -128,6 +128,10 @@ export default {
       }
       return false
     },
+    getAdditionalData() {
+      // This is a placeholder that gets overridden in the component if it needs to load extra data
+      return Promise.resolve()
+    }
   },
   computed: {
     listTitle() {
@@ -148,6 +152,8 @@ export default {
   mounted() {
     this.search = this.$api.storage.getItem(this.searchStorageKey, 'session') || ''
     this.isLoading = true
-    this.getSetItems().then(() => (this.isLoading = false))
+    this.getAdditionalData().then(() => {
+      this.getSetItems().then(() => (this.isLoading = false))
+    })
   },
 }

--- a/src/components/user/IFXUserList.vue
+++ b/src/components/user/IFXUserList.vue
@@ -19,6 +19,17 @@ export default {
       required: false,
       default: null,
     },
+    /* An array of buttons to put in the page header
+    * Each button should be an object with the following properties:
+    *   - icon: The icon to display on the button
+    *   - tooltip: The tooltip to display when the button is hovered over
+    *   - action: The method to call when the button is clicked
+    */
+    buttons: {
+      type: Array,
+      required: false,
+      default: null,
+    },
   },
   data() {
     return {
@@ -132,6 +143,18 @@ export default {
                 </div>
               </template>
               <span>Update Expense code / PO authorizations</span>
+            </v-tooltip>
+          </v-col>
+          <v-col v-if="buttons.length" class="d-flex flex-row flex-nowrap">
+            <v-tooltip top v-for="(button, index) in buttons" :key="index">
+              <template v-slot:activator="{ on, attrs }">
+                <div v-on="on">
+                  <v-btn v-bind="attrs" small fab @click="button.action(selected)" color="primary" :disabled="!selected.length" class="ml-2">
+                    <v-icon>{{button.icon}}</v-icon>
+                  </v-btn>
+                </div>
+              </template>
+              <span>{{ button.tooltip}}</span>
             </v-tooltip>
           </v-col>
         </v-row>


### PR DESCRIPTION
This PR allows an array of buttons and actions to be passed into `IFXUserList`. This allows components that use this to add some buttons to the header; `IFXUserList` will call back the `action` with the selected list of `User` objects. Currently needed by NICE.

Also add a stub function, `getAdditionalData`, that can be used by any component importing  `IFXItemListMixin.js` to load additional data from the backend without having to override `mounted` or `getSetItems` to do so.

