### PR TITLE
Fix IFXItemEditableDetailMixin

### DIFF
--- a/src/components/item/IFXItemCreateEditMixin.js
+++ b/src/components/item/IFXItemCreateEditMixin.js
@@ -39,6 +39,10 @@ export default {
       this.cachedItem = JSON.parse(JSON.stringify(this.item))
       // this.cachedItem = JSON.parse(JSON.stringify(this.apiRef.decompose(this.item)))
     },
+    getAdditionalData() {
+      // This is a placeholder that gets overridden in the component if it needs to load extra data
+      return Promise.resolve()
+    },
     can(ability, user = this.$api.authUser) {
       // if (!user) {
       //   // eslint-disable-next-line no-param-reassign
@@ -154,11 +158,13 @@ export default {
   },
   mounted() {
     this.isLoading = true
-    this.init()
-      .then(() => this.$nextTick(() => (this.isLoading = false)))
-      .catch((error) => {
-        this.showMessage(error)
-        this.rtr.replace({ name: 'Home' })
-      })
+    this.getAdditionalData().then(() => {
+      this.init()
+        .then(() => this.$nextTick(() => (this.isLoading = false)))
+        .catch((error) => {
+          this.showMessage(error)
+          this.rtr.replace({ name: 'Home' })
+        })
+    })
   },
 }

--- a/src/components/item/IFXItemEditableDetailMixin.js
+++ b/src/components/item/IFXItemEditableDetailMixin.js
@@ -22,6 +22,10 @@ export default {
     can(ability, user = this.$api.authUser) {
       return this.$api.auth.can(ability, user)
     },
+    getAdditionalData() {
+      // This is a placeholder that gets overridden in the component if it needs to load extra data
+      return Promise.resolve()
+    },
     getItem() {
       return this.apiRef.getByID(this.id)
     },
@@ -95,11 +99,13 @@ export default {
   },
   mounted() {
     this.isLoading = true
-    this.init()
-      .then(() => (this.isLoading = false))
-      .catch((err) => {
-        this.showMessage(err)
-        this.rtr.replace({ name: `${this.itemType}List` })
-      })
+    this.getAdditionalData().then(() => {
+      this.init()
+        .then(() => (this.isLoading = false))
+        .catch((err) => {
+          this.showMessage(err)
+          this.rtr.replace({ name: `${this.itemType}List` })
+        })
+    })
   },
 }

--- a/src/components/item/IFXItemEditableDetailMixin.js
+++ b/src/components/item/IFXItemEditableDetailMixin.js
@@ -11,6 +11,7 @@ export default {
     return {
       isLoading: false,
       isValid: false,
+      isEditing: true,
       item: {},
       cachedItem: {},
       errors: {},
@@ -20,6 +21,9 @@ export default {
     ...mapActions(['showMessage']),
     can(ability, user = this.$api.authUser) {
       return this.$api.auth.can(ability, user)
+    },
+    getItem() {
+      return this.apiRef.getByID(this.id)
     },
     async init() {
       try {

--- a/src/components/user/IFXUserList.vue
+++ b/src/components/user/IFXUserList.vue
@@ -28,7 +28,7 @@ export default {
     buttons: {
       type: Array,
       required: false,
-      default: null,
+      default: () => [],
     },
   },
   data() {
@@ -145,7 +145,7 @@ export default {
               <span>Update Expense code / PO authorizations</span>
             </v-tooltip>
           </v-col>
-          <v-col v-if="buttons.length" class="d-flex flex-row flex-nowrap">
+          <v-col v-if="buttons && buttons.length" class="d-flex flex-row flex-nowrap">
             <v-tooltip top v-for="(button, index) in buttons" :key="index">
               <template v-slot:activator="{ on, attrs }">
                 <div v-on="on">


### PR DESCRIPTION
This PR adds the `getAdditionalData` stub to both `IFXItemEditableDetailMixin` and `IFXItemCreateEditMixin`. In addition, it fixes a bug in `IFXItemEditableDetailMixin` where it didn't have the `getItem` function since the previous components that used it overrode that function. It's there now.

Also fix bug in `IFXUserList` component that didn't handle a missing `button` array.
