### PR TITLE
Add ability to delete billing records

### DIFF
--- a/src/api/IFXAPI.js
+++ b/src/api/IFXAPI.js
@@ -851,7 +851,7 @@ export default class IFXAPIService {
       const url = `${baseURL}${id}/`
       return this.axios.get(url).then((res) => createFunc(res.data))
     }
-    api.delete = () => ({ status: 501, message: 'Not implemented' })
+    // api.delete = () => ({ status: 501, message: 'Not implemented' })
     // eslint-disable-next-line no-unused-vars
     api.bulkUpdate = async (recs, app = null) => {
       const url = `${baseURL}bulk_update/`

--- a/src/api/IFXAPI.js
+++ b/src/api/IFXAPI.js
@@ -851,7 +851,6 @@ export default class IFXAPIService {
       const url = `${baseURL}${id}/`
       return this.axios.get(url).then((res) => createFunc(res.data))
     }
-    // api.delete = () => ({ status: 501, message: 'Not implemented' })
     // eslint-disable-next-line no-unused-vars
     api.bulkUpdate = async (recs, app = null) => {
       const url = `${baseURL}bulk_update/`

--- a/src/components/billingRecord/IFXBillingRecordList.vue
+++ b/src/components/billingRecord/IFXBillingRecordList.vue
@@ -61,6 +61,11 @@ export default {
       required: false,
       default: true,
     },
+    allowDeleteBillingRecords: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
     useDefaultMailButton: {
       type: Boolean,
       required: false,
@@ -210,6 +215,11 @@ export default {
         ? 'Cannot approve billing records that are FINAL'
         : 'Approve selected billing records'
     },
+    deleteSelectedToolTip: function () {
+      return this.billingRecordsAreFinal(this.selected)
+        ? 'Can only delete billing records that are INIT or PENDING_LAB_APPROVAL'
+        : 'Delete selected billing records'
+    },
     showCheckboxes: function () {
       return this.allowDownloads || this.allowApprovals || this.allowInvoiceGeneration
     },
@@ -256,6 +266,14 @@ export default {
         return false
       }
       const result = items.some((record) => record?.currentState === 'FINAL')
+      return result
+    },
+    billingRecordsAreInitOrPending(items) {
+      // Returns true if all records in the list are either in INIT or PENDING_LAB_APPROVAL state
+      if (!items || !items.length) {
+        return false
+      }
+      const result = items.every((record) => record?.currentState === 'INIT' || record?.currentState === 'LAB_APPROVED')
       return result
     },
     getItemsFilteredBySearch() {
@@ -589,6 +607,31 @@ export default {
           this.txnDialog = false
           this.editDialog = false
           this.showChangeExpenseCodeDialog = false
+        })
+    },
+    deleteSelectedBillingRecords() {
+      this.updating = true
+      const promises = []
+      for (let i = 0; i < this.selected.length; i++) {
+        promises.push(this.$api.billingRecord.delete(this.selected[i]))
+      }
+      Promise.all(promises)
+        .then((response) => {
+          const errors = response.filter((resp) => resp.error)
+          if (errors.length) {
+            this.showMessage(response.error)
+          }
+          this.showMessage(`Successfully deleted ${response.data.length - errors.length} billing record(s)`)
+          this.items = this.items.filter((item) => !this.selected.includes(item))
+          this.selected = []
+        })
+        .catch((error) => {
+          this.isLoading = false
+          const message = this.getErrorMessage(error)
+          this.showMessage(message)
+        })
+        .finally(() => {
+          this.updating = false
         })
     },
     async openEditDialog(item) {
@@ -1031,6 +1074,25 @@ export default {
                         </v-tooltip>
                       </v-col>
                     </v-row>
+                  </v-col>
+                  <v-col v-if="allowDeleteBillingRecords">
+                    <v-tooltip top>
+                      <template v-slot:activator="{ on, attrs }">
+                        <div v-on="on">
+                          <v-btn
+                            :disabled="selected.length == 0 || billingRecordsAreInitOrPending(selected)"
+                            v-bind="attrs"
+                            fab
+                            small
+                            color="red"
+                            @click="deleteSelectedBillingRecords()"
+                          >
+                            <v-icon dark>mdi-trash-can-outline</v-icon>
+                          </v-btn>
+                        </div>
+                      </template>
+                      <span>{{ deleteSelectedToolTip }}</span>
+                    </v-tooltip>
                   </v-col>
                 </v-row>
               </v-col>

--- a/src/components/billingRecord/IFXBillingRecordList.vue
+++ b/src/components/billingRecord/IFXBillingRecordList.vue
@@ -609,30 +609,24 @@ export default {
           this.showChangeExpenseCodeDialog = false
         })
     },
-    deleteSelectedBillingRecords() {
+    async deleteSelectedBillingRecords() {
       this.updating = true
-      const promises = []
+      let successCount = 0
       for (let i = 0; i < this.selected.length; i++) {
-        promises.push(this.$api.billingRecord.delete(this.selected[i]))
-      }
-      Promise.all(promises)
-        .then((response) => {
-          const errors = response.filter((resp) => resp.error)
-          if (errors.length) {
-            this.showMessage(response.error)
-          }
-          this.showMessage(`Successfully deleted ${response.data.length - errors.length} billing record(s)`)
-          this.items = this.items.filter((item) => !this.selected.includes(item))
-          this.selected = []
-        })
-        .catch((error) => {
-          this.isLoading = false
+        try {
+          await this.$api.billingRecord.delete(this.selected[i])
+          this.items = this.items.filter((item) => !(item.id === this.selected[i].id))
+          successCount++
+        } catch (error) {
           const message = this.getErrorMessage(error)
           this.showMessage(message)
-        })
-        .finally(() => {
-          this.updating = false
-        })
+        }
+      }
+      this.showMessage(`Successfully deleted ${successCount} billing record(s)`)
+      this.selected = []
+
+      this.isLoading = false
+      this.updating = false
     },
     async openEditDialog(item) {
       const index = this.items.findIndex((rec) => rec.id === item.id)

--- a/src/components/billingRecord/IFXBillingRecordListDecimal.vue
+++ b/src/components/billingRecord/IFXBillingRecordListDecimal.vue
@@ -61,6 +61,11 @@ export default {
       required: false,
       default: true,
     },
+    allowDeleteBillingRecords: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
     useDefaultMailButton: {
       type: Boolean,
       required: false,
@@ -212,6 +217,11 @@ export default {
         ? 'Cannot approve billing records that are FINAL'
         : 'Approve selected billing records'
     },
+    deleteSelectedToolTip: function () {
+      return this.billingRecordsAreFinal(this.selected)
+        ? 'Can only delete billing records that are INIT or PENDING_LAB_APPROVAL'
+        : 'Delete selected billing records'
+    },
     showCheckboxes: function () {
       return this.allowDownloads || this.allowApprovals || this.allowInvoiceGeneration
     },
@@ -258,6 +268,16 @@ export default {
         return false
       }
       const result = items.some((record) => record?.currentState === 'FINAL')
+      return result
+    },
+    billingRecordsAreInitOrPending(items) {
+      // Returns true if all records in the list are either in INIT or PENDING_LAB_APPROVAL state
+      if (!items || !items.length) {
+        return false
+      }
+      const result = items.every(
+        (record) => record?.currentState === 'INIT' || record?.currentState === 'PENDING_LAB_APPROVAL'
+      )
       return result
     },
     getItemsFilteredBySearch() {
@@ -592,6 +612,31 @@ export default {
           this.txnDialog = false
           this.editDialog = false
           this.showChangeExpenseCodeDialog = false
+        })
+    },
+    deleteSelectedBillingRecords() {
+      this.updating = true
+      const promises = []
+      for (let i = 0; i < this.selected.length; i++) {
+        promises.push(this.$api.billingRecord.delete(this.selected[i]))
+      }
+      Promise.all(promises)
+        .then((response) => {
+          const errors = response.filter((resp) => resp.error)
+          if (errors.length) {
+            this.showMessage(response.error)
+          }
+          this.showMessage(`Successfully deleted ${response.length - errors.length} billing record(s)`)
+          this.items = this.items.filter((item) => !this.selected.includes(item))
+          this.selected = []
+        })
+        .catch((error) => {
+          this.isLoading = false
+          const message = this.getErrorMessage(error)
+          this.showMessage(message)
+        })
+        .finally(() => {
+          this.updating = false
         })
     },
     async openEditDialog(item) {
@@ -1034,6 +1079,25 @@ export default {
                         </v-tooltip>
                       </v-col>
                     </v-row>
+                  </v-col>
+                  <v-col v-if="allowDeleteBillingRecords">
+                    <v-tooltip top>
+                      <template v-slot:activator="{ on, attrs }">
+                        <div v-on="on">
+                          <v-btn
+                            :disabled="selected.length == 0 || !billingRecordsAreInitOrPending(selected)"
+                            v-bind="attrs"
+                            fab
+                            small
+                            color="red"
+                            @click="deleteSelectedBillingRecords()"
+                          >
+                            <v-icon dark>mdi-trash-can-outline</v-icon>
+                          </v-btn>
+                        </div>
+                      </template>
+                      <span>{{ deleteSelectedToolTip }}</span>
+                    </v-tooltip>
                   </v-col>
                 </v-row>
               </v-col>

--- a/src/components/billingRecord/IFXBillingRecordListDecimal.vue
+++ b/src/components/billingRecord/IFXBillingRecordListDecimal.vue
@@ -614,30 +614,24 @@ export default {
           this.showChangeExpenseCodeDialog = false
         })
     },
-    deleteSelectedBillingRecords() {
+    async deleteSelectedBillingRecords() {
       this.updating = true
-      const promises = []
+      let successCount = 0
       for (let i = 0; i < this.selected.length; i++) {
-        promises.push(this.$api.billingRecord.delete(this.selected[i]))
-      }
-      Promise.all(promises)
-        .then((response) => {
-          const errors = response.filter((resp) => resp.error)
-          if (errors.length) {
-            this.showMessage(response.error)
-          }
-          this.showMessage(`Successfully deleted ${response.length - errors.length} billing record(s)`)
-          this.items = this.items.filter((item) => !this.selected.includes(item))
-          this.selected = []
-        })
-        .catch((error) => {
-          this.isLoading = false
+        try {
+          await this.$api.billingRecord.delete(this.selected[i])
+          this.items = this.items.filter((item) => !(item.id === this.selected[i].id))
+          successCount++
+        } catch (error) {
           const message = this.getErrorMessage(error)
           this.showMessage(message)
-        })
-        .finally(() => {
-          this.updating = false
-        })
+        }
+      }
+      this.showMessage(`Successfully deleted ${successCount} billing record(s)`)
+      this.selected = []
+
+      this.isLoading = false
+      this.updating = false
     },
     async openEditDialog(item) {
       const index = this.items.findIndex((rec) => rec.id === item.id)

--- a/src/components/billingRecord/IFXBillingRecords.vue
+++ b/src/components/billingRecord/IFXBillingRecords.vue
@@ -21,6 +21,16 @@ export default {
       required: false,
       default: false,
     },
+    allowChangeExpenseCode: {
+      type: Boolean,
+      required: false,
+      default: true,
+    },
+    allowDeleteBillingRecords: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
     showDates: {
       type: Boolean,
       required: false,
@@ -152,6 +162,8 @@ export default {
             :allowApprovals="false"
             :allowDownloads="allowDownloads"
             :useDefaultMailButton="useDefaultMailButton"
+            :allowChangeExpenseCode="allowChangeExpenseCode"
+            :allowDeleteBillingRecords="allowDeleteBillingRecords"
             :showDates="showDates"
             :showTotals="showTotals"
             :totalUnits="totalUnits"


### PR DESCRIPTION
This PR adds the ability to delete individual billing records. It is controlled by a prop, `allowDeleteBillingRecords` and the billing records have to be in either `INIT` or `PENDING_LAB_APPROVAL` state to enable the button.

Also, the props `allowDeleteBillingRecords` and `allowChangeExpenseCode` are now passed through the `IFXBillingRecords` component to the `IFXBillingRecordListDecimal` and `IFXBillingRecordList` components, although I don't this we use the latter any longer.
