### PR TITLE
Add `tab` attribute to the `query` object when routing to a new page

### DIFF
--- a/src/components/item/IFXItemCreateEditMixin.js
+++ b/src/components/item/IFXItemCreateEditMixin.js
@@ -108,6 +108,9 @@ export default {
             if (this.$route.query.page) {
               query.page = this.$route.query.page
             }
+            if (this.$route.query.tab) {
+              query.tab = this.$route.query.tab
+            }
             this.$router.push({ path: this.$route.query.next, query })
           } else {
             this.rtr.push({ name: this.itemDetail, params: { id: res.data.id } })


### PR DESCRIPTION
This PR adds the `tab` attribute, if it exists, on the `$route.query` object to the new route being requested once a create/edit is done. This is so we can select the tab of a multi-tab page to return to; for example, the `TrainingEventList` page has individual TEs and Recurring Templates tabs. When creating a new Recurring Template, we can return to the Recurring Template tab directly.
