### PR TITLE
Pass the `tab` attribute, if it exists, in as a query param for updates

### DIFF
--- a/src/components/item/IFXItemCreateEditMixin.js
+++ b/src/components/item/IFXItemCreateEditMixin.js
@@ -81,6 +81,9 @@ export default {
             if (this.$route.query.page) {
               query.page = this.$route.query.page
             }
+            if (this.$route.query.tab) {
+              query.tab = this.$route.query.tab
+            }
             this.$router.push({ path: this.$route.query.next, query })
           } else {
             this.rtr.push({ name: this.itemDetail, params: { id: res.data.id } })


### PR DESCRIPTION
This PR adds the `tab` attribute, if available, as a `query` param for updates just as the previous PR did for creating new items.