### PR TITLE
 Fix issues with `IFXUserDetail`

### DIFF
--- a/src/components/contact/IFXAffiliationRoleDisplayEdit.vue
+++ b/src/components/contact/IFXAffiliationRoleDisplayEdit.vue
@@ -109,7 +109,7 @@ export default {
         </template>
         <span>Reactivate affiliation</span>
       </v-tooltip>
-      <v-tooltip v-if="itemLocal.active">
+      <v-tooltip v-if="itemLocal.active" top>
         <template v-slot:activator="{ on, attrs }">
           <v-icon v-on="on" v-bind="attrs" class="ml-2" small color="primary" @click="toggleEditing">mdi-pencil</v-icon>
         </template>

--- a/src/components/user/IFXUserDetail.vue
+++ b/src/components/user/IFXUserDetail.vue
@@ -64,14 +64,6 @@ export default {
   },
   methods: {
     ...mapActions(['showMessage']),
-    // async init() {
-    //   this.item = await this.apiRef.getByID(this.id, true)
-    //   this.cacheItem()
-    //   this.allContacts = await this.$api.contact.getList({ has_name: false })
-    //   this.allGroupNames = await this.$api.group.getNames()
-    //   const organizations = await this.$api.organization.getNames()
-    //   this.allOrganizationSlugs = organizations.map((o) => o.slug)
-    // },
     async getAdditionalData() {
       this.allContacts = await this.$api.contact.getList({ has_name: false })
       this.allGroupNames = await this.$api.group.getNames()

--- a/src/components/user/IFXUserDetail.vue
+++ b/src/components/user/IFXUserDetail.vue
@@ -2,11 +2,10 @@
 import { mapActions } from 'vuex'
 
 import IFXUserMixin from '@/components/user/IFXUserMixin'
-import IFXItemDetailMixin from '@/components/item/IFXItemDetailMixin'
+import IFXItemEditableDetailMixin from '@/components/item/IFXItemEditableDetailMixin'
 import IFXLoginIcon from '@/components/IFXLoginIcon'
 import IFXUserInfoEdit from '@/components/user/IFXUserInfoEdit'
 
-import IFXItemCreateEditMixin from '@/components/item/IFXItemCreateEditMixin'
 import IFXUserInfoDialog from '@/components/user/IFXUserInfoDialog'
 import IFXSelectCreateContact from '@/components/contact/IFXSelectCreateContact'
 import IFXSelectAffiliation from '@/components/affiliation/IFXSelectAffiliation'
@@ -17,7 +16,7 @@ import cloneDeep from 'lodash/cloneDeep'
 
 export default {
   name: 'IFXUserDetail',
-  mixins: [IFXUserMixin, IFXItemDetailMixin, IFXItemCreateEditMixin],
+  mixins: [IFXUserMixin, IFXItemEditableDetailMixin],
   components: {
     IFXLoginIcon,
     IFXUserInfoEdit,

--- a/src/components/user/IFXUserDetail.vue
+++ b/src/components/user/IFXUserDetail.vue
@@ -64,9 +64,15 @@ export default {
   },
   methods: {
     ...mapActions(['showMessage']),
-    async init() {
-      this.item = await this.apiRef.getByID(this.id, true)
-      this.cacheItem()
+    // async init() {
+    //   this.item = await this.apiRef.getByID(this.id, true)
+    //   this.cacheItem()
+    //   this.allContacts = await this.$api.contact.getList({ has_name: false })
+    //   this.allGroupNames = await this.$api.group.getNames()
+    //   const organizations = await this.$api.organization.getNames()
+    //   this.allOrganizationSlugs = organizations.map((o) => o.slug)
+    // },
+    async getAdditionalData() {
       this.allContacts = await this.$api.contact.getList({ has_name: false })
       this.allGroupNames = await this.$api.group.getNames()
       const organizations = await this.$api.organization.getNames()


### PR DESCRIPTION
This PR fixes some issues with `IFXUserDetail`:

- All the data was being fetched twice. This was caused by having two mixins, `IFXItemDetailMixin` and `IFXItemCreateEditMixin`, both of which had a `mounted` hook that called the `init` routine. These have been replaced with `IFXItemEditableDetailMixin`
- The `init` function isn't needed any longer; we can use the new `getAdditionalData` function to fetch our additional data
- Fixed a small bug where the tooltip for editing affiliations appeared at the top of the browser
