### PR TITLE
Add an overlay with spinner when submitting data to the backend

### DIFF
--- a/src/AppTemplate.vue
+++ b/src/AppTemplate.vue
@@ -23,9 +23,7 @@ export default {
           <v-card>
             <v-card-title>
               <v-row>
-                <v-col>
-                  Local App
-                </v-col>
+                <v-col>Local App</v-col>
               </v-row>
             </v-card-title>
             <v-card-text class="text-body-1">
@@ -58,7 +56,7 @@ export default {
             <v-card-actions>
               <v-row>
                 <v-col>
-                  <IFXPageActionBar btnType="submit" btnText="Click me!" :disabled="false" />
+                  <IFXPageActionBar btnType="submit" btnText="Click me!" :disabled="false" :submitting="submitting" />
                 </v-col>
               </v-row>
             </v-card-actions>

--- a/src/components/contact/IFXEmailContactCreateEdit.vue
+++ b/src/components/contact/IFXEmailContactCreateEdit.vue
@@ -26,15 +26,15 @@ export default {
 }
 </script>
 <template>
-  <v-form v-if='!isLoading' v-model='isValid'>
+  <v-form v-if="!isLoading" v-model="isValid">
     <v-row dense>
       <v-col>
         <v-text-field
-          v-model='item.name'
-          label='Name'
-          data-cy='name'
-          :rules='formRules.generic'
-          :error-messages='errors.name'
+          v-model="item.name"
+          label="Name"
+          data-cy="name"
+          :rules="formRules.generic"
+          :error-messages="errors.name"
           required
         ></v-text-field>
       </v-col>
@@ -42,18 +42,18 @@ export default {
     <v-row dense>
       <v-col>
         <v-text-field
-          v-model='item.detail'
-          label='Email'
-          data-cy='email'
-          :rules='formRules.email'
-          :error-messages='errors.detail'
+          v-model="item.detail"
+          label="Email"
+          data-cy="email"
+          :rules="formRules.email"
+          :error-messages="errors.detail"
           required
         ></v-text-field>
       </v-col>
     </v-row>
     <v-row dense>
       <v-col>
-        <IFXPageActionBar :disabled="!isSubmittable" btnType="submit" @action="submit" />
+        <IFXPageActionBar :disabled="!isSubmittable" btnType="submit" @action="submit" :submitting="submitting" />
       </v-col>
     </v-row>
   </v-form>

--- a/src/components/contact/IFXFullContactCreateEdit.vue
+++ b/src/components/contact/IFXFullContactCreateEdit.vue
@@ -22,62 +22,49 @@ export default {
       }
       this.cachedItem = JSON.parse(JSON.stringify(this.item))
       // TODO: only get chunks
-      this.allUsers = await this.$api.user.getList()
-        .catch(err => this.showMessage(err))
+      this.allUsers = await this.$api.user.getList().catch((err) => this.showMessage(err))
     },
   },
 }
 </script>
 <template>
   <v-container>
-    <v-form v-if='!isLoading' v-model='isValid'>
+    <v-form v-if="!isLoading" v-model="isValid">
       <v-row>
         <v-col>
           <v-text-field
-            v-model='item.name'
-            label='Name'
-            data-cy='name'
-            :rules='formRules.generic'
-            :error-messages='errors.name'
+            v-model="item.name"
+            label="Name"
+            data-cy="name"
+            :rules="formRules.generic"
+            :error-messages="errors.name"
             required
           ></v-text-field>
         </v-col>
         <v-col>
           <v-text-field
-            v-model='item.detail'
-            label='Email'
-            data-cy='email'
-            :rules='formRules.email'
-            :error-messages='errors.detail'
+            v-model="item.detail"
+            label="Email"
+            data-cy="email"
+            :rules="formRules.email"
+            :error-messages="errors.detail"
             required
           ></v-text-field>
         </v-col>
       </v-row>
       <v-row>
         <v-col>
-          <v-text-field
-            v-model='item.phone'
-            label='Phone'
-            data-cy='phone'
-            :rules='formRules.phone'
-          >
-          </v-text-field>
+          <v-text-field v-model="item.phone" label="Phone" data-cy="phone" :rules="formRules.phone"></v-text-field>
         </v-col>
       </v-row>
       <v-row>
         <v-col>
-          <v-textarea
-            v-model='item.address'
-            label='Address'
-            data-cy='address'
-            auto-grow
-            :rows="3"
-          ></v-textarea>
+          <v-textarea v-model="item.address" label="Address" data-cy="address" auto-grow :rows="3"></v-textarea>
         </v-col>
       </v-row>
       <v-row>
         <v-col>
-          <IFXPageActionBar :disabled="!isSubmittable" btnType="submit" @action="submit" />
+          <IFXPageActionBar :disabled="!isSubmittable" btnType="submit" @action="submit" :submitting="submitting" />
         </v-col>
       </v-row>
     </v-form>

--- a/src/components/contact/IFXPhoneContactCreateEdit.vue
+++ b/src/components/contact/IFXPhoneContactCreateEdit.vue
@@ -22,20 +22,20 @@ export default {
   },
   mounted() {
     this.item.type = 'Phone'
-  }
+  },
 }
 </script>
 <template>
   <v-container>
-    <v-form v-if='!isLoading' v-model='isValid'>
+    <v-form v-if="!isLoading" v-model="isValid">
       <v-row>
         <v-col>
           <v-text-field
-            v-model='item.name'
-            label='Name'
-            data-cy='name'
-            :rules='formRules.generic'
-            :error-messages='errors.name'
+            v-model="item.name"
+            label="Name"
+            data-cy="name"
+            :rules="formRules.generic"
+            :error-messages="errors.name"
             required
           ></v-text-field>
         </v-col>
@@ -43,18 +43,18 @@ export default {
       <v-row>
         <v-col>
           <v-text-field
-            v-model='item.detail'
-            label='Phone'
-            data-cy='phone'
-            :rules='formRules.phone'
-            :error-messages='errors.detail'
+            v-model="item.detail"
+            label="Phone"
+            data-cy="phone"
+            :rules="formRules.phone"
+            :error-messages="errors.detail"
             required
           ></v-text-field>
         </v-col>
       </v-row>
       <v-row>
         <v-col>
-          <IFXPageActionBar :disabled="!isSubmittable" btnType="submit" @action="submit" />
+          <IFXPageActionBar :disabled="!isSubmittable" btnType="submit" @action="submit" :submitting="submitting" />
         </v-col>
       </v-row>
     </v-form>

--- a/src/components/item/IFXItemCreateEditMixin.js
+++ b/src/components/item/IFXItemCreateEditMixin.js
@@ -24,6 +24,7 @@ export default {
       item: {},
       cachedItem: {},
       errors: {},
+      submitting: false,
     }
   },
   methods: {
@@ -68,9 +69,11 @@ export default {
       }
     },
     submitUpdate() {
+      this.submitting = true
       this.apiRef
         .update(this.item)
         .then(async (res) => {
+          this.submitting = false
           const message = `${this.itemType} updated successfully.`
           this.showMessage(message)
           await this.sleep(this.routeDelay)
@@ -87,6 +90,7 @@ export default {
           }
         })
         .catch((error) => {
+          this.submitting = false
           const { response } = error
           if (response) {
             this.errors = response.data
@@ -95,9 +99,11 @@ export default {
         })
     },
     submitSave() {
+      this.submitting = true
       this.apiRef
         .save(this.item)
         .then(async (res) => {
+          this.submitting = false
           const message = `${this.itemType} created with ID: ${res.data.id}.`
           this.showMessage(message)
           await this.sleep(this.routeDelay)
@@ -117,6 +123,7 @@ export default {
           }
         })
         .catch((error) => {
+          this.submitting = false
           const { response } = error
           if (response) {
             this.errors = response.data

--- a/src/components/item/IFXItemEditableDetailMixin.js
+++ b/src/components/item/IFXItemEditableDetailMixin.js
@@ -15,6 +15,7 @@ export default {
       item: {},
       cachedItem: {},
       errors: {},
+      submitting: false,
     }
   },
   methods: {
@@ -58,9 +59,11 @@ export default {
       }
     },
     submitUpdate() {
+      this.submitting = true
       this.apiRef
         .update(this.item)
         .then(async (res) => {
+          this.submitting = false
           const message = `${this.itemType} updated successfully.`
           this.showMessage(message)
           await this.sleep(this.routeDelay)
@@ -71,6 +74,7 @@ export default {
           }
         })
         .catch((error) => {
+          this.submitting = false
           const { response } = error
           if (response) {
             this.errors = response.data

--- a/src/components/message/IFXMessageCreateEdit.vue
+++ b/src/components/message/IFXMessageCreateEdit.vue
@@ -24,14 +24,15 @@ export default {
           'advlist autolink lists link image charmap',
           'searchreplace visualblocks fullscreen',
           'print preview anchor insertdatetime media',
-          'paste code help wordcount table'
+          'paste code help wordcount table',
         ],
-        toolbar: 'undo redo | code | formatselect | bold italic | alignleft aligncenter alignright | bullist numlist outdent indent | help',
+        toolbar:
+          'undo redo | code | formatselect | bold italic | alignleft aligncenter alignright | bullist numlist outdent indent | help',
       }
     },
     messageTitle() {
       return this.item.displayName ? `Edit ${this.item.displayName}` : `Edit Message ${this.item.id}`
-    }
+    },
   },
   methods: {
     async getItem() {
@@ -69,15 +70,12 @@ export default {
         </v-row>
         <v-row>
           <v-col>
-            <Editor
-              v-model="item.message"
-              :init="editorInit"
-            ></Editor>
+            <Editor v-model="item.message" :init="editorInit"></Editor>
           </v-col>
         </v-row>
         <v-row>
           <v-col>
-            <IFXPageActionBar :disabled="!isValid" btnType="submit" @action="submit" />
+            <IFXPageActionBar :disabled="!isValid" btnType="submit" @action="submit" :submitting="submitting" />
           </v-col>
         </v-row>
       </v-form>

--- a/src/components/organization/IFXOrganizationCreateEdit.vue
+++ b/src/components/organization/IFXOrganizationCreateEdit.vue
@@ -133,22 +133,25 @@ export default {
         <v-row>
           <v-col>
             <IFXItemSelectList
-              title='Contacts'
-              :items.sync='item.contacts'
-              :getEmptyItem='$api.organizationContact.create'
-              >
-              <template v-slot="{item}">
-                <IFXSelectableContact :allItems='allContacts' :item='item' :errors='errors' @check-valid-form="checkValidForm()"/>
+              title="Contacts"
+              :items.sync="item.contacts"
+              :getEmptyItem="$api.organizationContact.create"
+            >
+              <template v-slot="{ item }">
+                <IFXSelectableContact
+                  :allItems="allContacts"
+                  :item="item"
+                  :errors="errors"
+                  @check-valid-form="checkValidForm()"
+                />
               </template>
             </IFXItemSelectList>
           </v-col>
         </v-row>
         <v-row justify="end">
-          <v-col class="flex flex-grow-1 flex-grow-0">
-            &nbsp;
-          </v-col>
+          <v-col class="flex flex-grow-1 flex-grow-0">&nbsp;</v-col>
           <v-col>
-            <IFXPageActionBar btnType="submit" :disabled="!isSubmittable" @action="submit" />
+            <IFXPageActionBar btnType="submit" :disabled="!isSubmittable" @action="submit" :submitting="submitting" />
           </v-col>
         </v-row>
       </v-form>

--- a/src/components/organization/IFXOrganizationDetail.vue
+++ b/src/components/organization/IFXOrganizationDetail.vue
@@ -338,6 +338,7 @@ export default {
       btnType="submit"
       :disabled="!isSubmittable"
       @action="updateUsersAndSubmit"
+      :submitting="submitting"
     ></IFXPageActionBar>
     <v-dialog v-model="contactDialogOpen" v-if="contactDialogOpen" max-width="600px" persistent>
       <v-card>

--- a/src/components/page/IFXPageActionBar.vue
+++ b/src/components/page/IFXPageActionBar.vue
@@ -18,11 +18,14 @@ export default {
       type: String,
       required: false,
     },
+    submitting: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
   },
   data() {
-    return {
-      show: true,
-    }
+    return {}
   },
   computed: {},
   methods: {
@@ -43,6 +46,12 @@ export default {
         <IFXButton :btnType="btnType" :disabled="disabled" :btnText="btnText" @action="handleAction" />
       </slot>
     </v-col>
+    <v-overlay :value="submitting">
+      <span class="d-flex align-center elevation-2 pa-4 rounded-lg grey darken-1">
+        <v-progress-circular indeterminate size="64"></v-progress-circular>
+        <em class="ml-4 text-body-1">Our network minions are carrying data to the server...</em>
+      </span>
+    </v-overlay>
   </v-row>
 </template>
 

--- a/src/components/product/IFXProductCreateEdit.vue
+++ b/src/components/product/IFXProductCreateEdit.vue
@@ -152,12 +152,7 @@ export default {
             ></v-select>
           </v-col>
           <v-col>
-            <v-checkbox
-              class="mt-0 pt-0"
-              v-model="item.billable"
-              label="Billable"
-              data-cy="billable"
-            ></v-checkbox>
+            <v-checkbox class="mt-0 pt-0" v-model="item.billable" label="Billable" data-cy="billable"></v-checkbox>
           </v-col>
         </v-row>
         <v-row>
@@ -185,8 +180,7 @@ export default {
               return-object
               :rules="formRules.generic"
               @focus="clearError('parent')"
-            >
-            </v-autocomplete>
+            ></v-autocomplete>
           </v-col>
         </v-row>
         <v-row>
@@ -314,7 +308,7 @@ export default {
             </IFXItemDataTable>
           </v-col>
         </v-row>
-        <IFXPageActionBar btnType="submit" :disabled="!isSubmittable" @action="submit" />
+        <IFXPageActionBar btnType="submit" :disabled="!isSubmittable" @action="submit" :submitting="submitting" />
       </v-form>
     </v-container>
   </v-container>

--- a/src/components/user/IFXUserDetail.vue
+++ b/src/components/user/IFXUserDetail.vue
@@ -372,6 +372,7 @@ export default {
         btnType="submit"
         @action="openCommentDialog"
         :disabled="!isSubmittable"
+        :submitting="submitting"
       ></IFXPageActionBar>
       <v-dialog v-model="userInfoDialogOpen" v-if="userInfoDialogOpen" max-width="80vw" persistent>
         <v-card>

--- a/src/components/user/IFXUserEdit.vue
+++ b/src/components/user/IFXUserEdit.vue
@@ -24,8 +24,7 @@ export default {
     IFXSelectableAffiliation,
     IFXPageActionBar,
   },
-  props: {
-  },
+  props: {},
   data() {
     return {
       isDialogActive: false,
@@ -282,7 +281,7 @@ export default {
               </IFXItemSelectList>
             </v-col>
           </v-row>
-          <IFXPageActionBar btnType="submit" @action="openDialog" :disabled="!isSubmittable"></IFXPageActionBar>
+          <IFXPageActionBar btnType="submit" @action="openDialog" :disabled="!isSubmittable" :submitting="submitting" />
         </v-form>
       </v-container>
       <IFXUserEditWarning v-else :user="item" />


### PR DESCRIPTION
This PR adds an overlay and spinner, and cute message, to the `IFXPageActionBar` component; this is controlled via the `submitting` prop. It also adds a `submitting` flag to both `IFXItemCreateEditMixin` and `IFXItemEditableDetailMixin` that is set/cleared when data is submitted.

For pages that uses these defaults,  the overlay shows up when data is submitted and is cleared when a result or error is returned. If a page has its own `submitSave` or `submitUpdate`, it is responsible for setting/clearing `submitting` and passing it into `IFXPageActionBar`.

Pages, in general, will have to pass in the new prop. This PR addresses the components/pages in `IFXVue`