### PR TITLE
Convert the "updating" overlay to use Vuex actions with a slight delay

### DIFF
--- a/src/AppTemplate.vue
+++ b/src/AppTemplate.vue
@@ -56,7 +56,7 @@ export default {
             <v-card-actions>
               <v-row>
                 <v-col>
-                  <IFXPageActionBar btnType="submit" btnText="Click me!" :disabled="false" :submitting="submitting" />
+                  <IFXPageActionBar btnType="submit" btnText="Click me!" :disabled="false"/>
                 </v-col>
               </v-row>
             </v-card-actions>

--- a/src/components/contact/IFXEmailContactCreateEdit.vue
+++ b/src/components/contact/IFXEmailContactCreateEdit.vue
@@ -53,7 +53,7 @@ export default {
     </v-row>
     <v-row dense>
       <v-col>
-        <IFXPageActionBar :disabled="!isSubmittable" btnType="submit" @action="submit" :submitting="submitting" />
+        <IFXPageActionBar :disabled="!isSubmittable" btnType="submit" @action="submit" />
       </v-col>
     </v-row>
   </v-form>

--- a/src/components/contact/IFXFullContactCreateEdit.vue
+++ b/src/components/contact/IFXFullContactCreateEdit.vue
@@ -64,7 +64,7 @@ export default {
       </v-row>
       <v-row>
         <v-col>
-          <IFXPageActionBar :disabled="!isSubmittable" btnType="submit" @action="submit" :submitting="submitting" />
+          <IFXPageActionBar :disabled="!isSubmittable" btnType="submit" @action="submit" />
         </v-col>
       </v-row>
     </v-form>

--- a/src/components/contact/IFXPhoneContactCreateEdit.vue
+++ b/src/components/contact/IFXPhoneContactCreateEdit.vue
@@ -54,7 +54,7 @@ export default {
       </v-row>
       <v-row>
         <v-col>
-          <IFXPageActionBar :disabled="!isSubmittable" btnType="submit" @action="submit" :submitting="submitting" />
+          <IFXPageActionBar :disabled="!isSubmittable" btnType="submit" @action="submit" />
         </v-col>
       </v-row>
     </v-form>

--- a/src/components/item/IFXItemCreateEditMixin.js
+++ b/src/components/item/IFXItemCreateEditMixin.js
@@ -24,7 +24,6 @@ export default {
       item: {},
       cachedItem: {},
       errors: {},
-      submitting: false,
     }
   },
   methods: {
@@ -69,11 +68,11 @@ export default {
       }
     },
     submitUpdate() {
-      this.submitting = true
+      this.$store.commit('submit/submitting', true)
       this.apiRef
         .update(this.item)
         .then(async (res) => {
-          this.submitting = false
+          this.$store.commit('submit/submitting', false)
           const message = `${this.itemType} updated successfully.`
           this.showMessage(message)
           await this.sleep(this.routeDelay)
@@ -90,7 +89,7 @@ export default {
           }
         })
         .catch((error) => {
-          this.submitting = false
+          this.$store.commit('submit/submitting', false)
           const { response } = error
           if (response) {
             this.errors = response.data
@@ -99,11 +98,11 @@ export default {
         })
     },
     submitSave() {
-      this.submitting = true
+      this.$store.commit('submit/submitting', true)
       this.apiRef
         .save(this.item)
         .then(async (res) => {
-          this.submitting = false
+          this.$store.commit('submit/submitting', false)
           const message = `${this.itemType} created with ID: ${res.data.id}.`
           this.showMessage(message)
           await this.sleep(this.routeDelay)
@@ -123,7 +122,7 @@ export default {
           }
         })
         .catch((error) => {
-          this.submitting = false
+          this.$store.commit('submit/submitting', false)
           const { response } = error
           if (response) {
             this.errors = response.data

--- a/src/components/item/IFXItemCreateEditMixin.js
+++ b/src/components/item/IFXItemCreateEditMixin.js
@@ -27,7 +27,7 @@ export default {
     }
   },
   methods: {
-    ...mapActions(['showMessage']),
+    ...mapActions(['showMessage', 'submit/setSubmitting']),
     async init() {
       try {
         this.item = await this.getItem()
@@ -68,11 +68,11 @@ export default {
       }
     },
     submitUpdate() {
-      this.$store.commit('submit/submitting', true)
+      this.$store.dispatch('submit/setSubmitting', true)
       this.apiRef
         .update(this.item)
         .then(async (res) => {
-          this.$store.commit('submit/submitting', false)
+          this.$store.dispatch('submit/setSubmitting', false)
           const message = `${this.itemType} updated successfully.`
           this.showMessage(message)
           await this.sleep(this.routeDelay)
@@ -89,7 +89,7 @@ export default {
           }
         })
         .catch((error) => {
-          this.$store.commit('submit/submitting', false)
+          this.$store.dispatch('submit/setSubmitting', false)
           const { response } = error
           if (response) {
             this.errors = response.data
@@ -98,11 +98,11 @@ export default {
         })
     },
     submitSave() {
-      this.$store.commit('submit/submitting', true)
+      this.$store.dispatch('submit/setSubmitting', true)
       this.apiRef
         .save(this.item)
         .then(async (res) => {
-          this.$store.commit('submit/submitting', false)
+          this.$store.dispatch('submit/setSubmitting', false)
           const message = `${this.itemType} created with ID: ${res.data.id}.`
           this.showMessage(message)
           await this.sleep(this.routeDelay)
@@ -122,7 +122,7 @@ export default {
           }
         })
         .catch((error) => {
-          this.$store.commit('submit/submitting', false)
+          this.$store.dispatch('submit/setSubmitting', false)
           const { response } = error
           if (response) {
             this.errors = response.data

--- a/src/components/item/IFXItemEditableDetailMixin.js
+++ b/src/components/item/IFXItemEditableDetailMixin.js
@@ -18,7 +18,7 @@ export default {
     }
   },
   methods: {
-    ...mapActions(['showMessage']),
+    ...mapActions(['showMessage', 'submit/setSubmitting']),
     can(ability, user = this.$api.authUser) {
       return this.$api.auth.can(ability, user)
     },
@@ -58,11 +58,11 @@ export default {
       }
     },
     submitUpdate() {
-      this.$store.commit('submit/submitting', true)
+      this.$store.dispatch('submit/setSubmitting', true)
       this.apiRef
         .update(this.item)
         .then(async (res) => {
-          this.$store.commit('submit/submitting', false)
+          this.$store.dispatch('submit/setSubmitting', false)
           const message = `${this.itemType} updated successfully.`
           this.showMessage(message)
           await this.sleep(this.routeDelay)
@@ -73,7 +73,7 @@ export default {
           }
         })
         .catch((error) => {
-          this.$store.commit('submit/submitting', false)
+          this.$store.dispatch('submit/setSubmitting', false)
           const { response } = error
           if (response) {
             this.errors = response.data

--- a/src/components/item/IFXItemEditableDetailMixin.js
+++ b/src/components/item/IFXItemEditableDetailMixin.js
@@ -15,7 +15,6 @@ export default {
       item: {},
       cachedItem: {},
       errors: {},
-      submitting: false,
     }
   },
   methods: {
@@ -59,11 +58,11 @@ export default {
       }
     },
     submitUpdate() {
-      this.submitting = true
+      this.$store.commit('submit/submitting', true)
       this.apiRef
         .update(this.item)
         .then(async (res) => {
-          this.submitting = false
+          this.$store.commit('submit/submitting', false)
           const message = `${this.itemType} updated successfully.`
           this.showMessage(message)
           await this.sleep(this.routeDelay)
@@ -74,7 +73,7 @@ export default {
           }
         })
         .catch((error) => {
-          this.submitting = false
+          this.$store.commit('submit/submitting', false)
           const { response } = error
           if (response) {
             this.errors = response.data

--- a/src/components/message/IFXMessageCreateEdit.vue
+++ b/src/components/message/IFXMessageCreateEdit.vue
@@ -75,7 +75,7 @@ export default {
         </v-row>
         <v-row>
           <v-col>
-            <IFXPageActionBar :disabled="!isValid" btnType="submit" @action="submit" :submitting="submitting" />
+            <IFXPageActionBar :disabled="!isValid" btnType="submit" @action="submit" />
           </v-col>
         </v-row>
       </v-form>

--- a/src/components/organization/IFXOrganizationCreateEdit.vue
+++ b/src/components/organization/IFXOrganizationCreateEdit.vue
@@ -151,7 +151,7 @@ export default {
         <v-row justify="end">
           <v-col class="flex flex-grow-1 flex-grow-0">&nbsp;</v-col>
           <v-col>
-            <IFXPageActionBar btnType="submit" :disabled="!isSubmittable" @action="submit" :submitting="submitting" />
+            <IFXPageActionBar btnType="submit" :disabled="!isSubmittable" @action="submit" />
           </v-col>
         </v-row>
       </v-form>

--- a/src/components/organization/IFXOrganizationDetail.vue
+++ b/src/components/organization/IFXOrganizationDetail.vue
@@ -338,7 +338,6 @@ export default {
       btnType="submit"
       :disabled="!isSubmittable"
       @action="updateUsersAndSubmit"
-      :submitting="submitting"
     ></IFXPageActionBar>
     <v-dialog v-model="contactDialogOpen" v-if="contactDialogOpen" max-width="600px" persistent>
       <v-card>

--- a/src/components/page/IFXPageActionBar.vue
+++ b/src/components/page/IFXPageActionBar.vue
@@ -1,6 +1,5 @@
 <script>
 import IFXButton from '@/components/IFXButton'
-import { mapGetters } from 'vuex'
 
 export default {
   name: 'IFXPageActionBar',
@@ -23,9 +22,6 @@ export default {
   data() {
     return {}
   },
-  computed: {
-    ...mapGetters('submit', ['isSubmitting']),
-  },
   methods: {
     /**
      * Emits event, triggering the action defined by the user.
@@ -44,12 +40,6 @@ export default {
         <IFXButton :btnType="btnType" :disabled="disabled" :btnText="btnText" @action="handleAction" />
       </slot>
     </v-col>
-    <v-overlay :value="isSubmitting">
-      <span class="d-flex align-center elevation-2 pa-4 rounded-lg grey darken-1">
-        <v-progress-circular indeterminate size="64"></v-progress-circular>
-        <em class="ml-4 text-body-1">Our network minions are carrying data to the server...</em>
-      </span>
-    </v-overlay>
   </v-row>
 </template>
 

--- a/src/components/page/IFXPageActionBar.vue
+++ b/src/components/page/IFXPageActionBar.vue
@@ -1,5 +1,6 @@
 <script>
 import IFXButton from '@/components/IFXButton'
+import { mapGetters } from 'vuex'
 
 export default {
   name: 'IFXPageActionBar',
@@ -18,16 +19,13 @@ export default {
       type: String,
       required: false,
     },
-    submitting: {
-      type: Boolean,
-      required: false,
-      default: false,
-    },
   },
   data() {
     return {}
   },
-  computed: {},
+  computed: {
+    ...mapGetters('submit', ['isSubmitting']),
+  },
   methods: {
     /**
      * Emits event, triggering the action defined by the user.
@@ -46,7 +44,7 @@ export default {
         <IFXButton :btnType="btnType" :disabled="disabled" :btnText="btnText" @action="handleAction" />
       </slot>
     </v-col>
-    <v-overlay :value="submitting">
+    <v-overlay :value="isSubmitting">
       <span class="d-flex align-center elevation-2 pa-4 rounded-lg grey darken-1">
         <v-progress-circular indeterminate size="64"></v-progress-circular>
         <em class="ml-4 text-body-1">Our network minions are carrying data to the server...</em>

--- a/src/components/page/IFXPageHeader.vue
+++ b/src/components/page/IFXPageHeader.vue
@@ -1,7 +1,10 @@
 <script>
+import { mapGetters } from 'vuex'
+
 export default {
   name: 'IFXPageHeader',
   computed: {
+    ...mapGetters('submit', ['isSubmitting']),
     /**
      * Determines if title slot is filled
      * @returns {boolean}
@@ -98,6 +101,12 @@ export default {
       </v-row>
     </v-col>
     <v-divider></v-divider>
+    <v-overlay :value="isSubmitting">
+      <span class="d-flex align-center elevation-2 pa-4 rounded-lg grey darken-1">
+        <v-progress-circular indeterminate size="64"></v-progress-circular>
+        <em class="ml-4 text-body-1">Updating...</em>
+      </span>
+    </v-overlay>
   </v-container>
 </template>
 

--- a/src/components/page/IFXPageHeader.vue
+++ b/src/components/page/IFXPageHeader.vue
@@ -101,7 +101,7 @@ export default {
       </v-row>
     </v-col>
     <v-divider></v-divider>
-    <v-overlay :value="isSubmitting">
+    <v-overlay :value="isSubmitting" z-index="300">
       <span class="d-flex align-center elevation-2 pa-4 rounded-lg grey darken-1">
         <v-progress-circular indeterminate size="64"></v-progress-circular>
         <em class="ml-4 text-body-1">Updating...</em>

--- a/src/components/product/IFXProductCreateEdit.vue
+++ b/src/components/product/IFXProductCreateEdit.vue
@@ -308,7 +308,7 @@ export default {
             </IFXItemDataTable>
           </v-col>
         </v-row>
-        <IFXPageActionBar btnType="submit" :disabled="!isSubmittable" @action="submit" :submitting="submitting" />
+        <IFXPageActionBar btnType="submit" :disabled="!isSubmittable" @action="submit" />
       </v-form>
     </v-container>
   </v-container>

--- a/src/components/user/IFXUserDetail.vue
+++ b/src/components/user/IFXUserDetail.vue
@@ -372,7 +372,6 @@ export default {
         btnType="submit"
         @action="openCommentDialog"
         :disabled="!isSubmittable"
-        :submitting="submitting"
       ></IFXPageActionBar>
       <v-dialog v-model="userInfoDialogOpen" v-if="userInfoDialogOpen" max-width="80vw" persistent>
         <v-card>

--- a/src/components/user/IFXUserEdit.vue
+++ b/src/components/user/IFXUserEdit.vue
@@ -281,7 +281,7 @@ export default {
               </IFXItemSelectList>
             </v-col>
           </v-row>
-          <IFXPageActionBar btnType="submit" @action="openDialog" :disabled="!isSubmittable" :submitting="submitting" />
+          <IFXPageActionBar btnType="submit" @action="openDialog" :disabled="!isSubmittable" />
         </v-form>
       </v-container>
       <IFXUserEditWarning v-else :user="item" />

--- a/src/entrypoint.js
+++ b/src/entrypoint.js
@@ -124,6 +124,7 @@ import IFXMixin from '@/mixins/IFXMixin'
 import IFXFilters from '@/filters/IFXFilters'
 import message from '@/vuex/message'
 import mailing from '@/vuex/mailing'
+import submit from '@/vuex/submit'
 
 // Calendars
 import IFXCalendarList from '@/components/calendar/IFXCalendarList'
@@ -247,6 +248,7 @@ export const ifxcomponents = {
 export const ifxmodules = {
   message,
   mailing,
+  submit,
 }
 
 /**

--- a/src/vuex/submit.js
+++ b/src/vuex/submit.js
@@ -3,17 +3,26 @@
 
 const getDefaultState = () => ({
   submitting: false,
+  timer: null,
 })
 
 const state = getDefaultState()
 
 const getters = {
   isSubmitting: (state) => state.submitting,
+  getTimer: (state) => state.timer,
 }
 
 const actions = {
   setSubmitting({ commit }, payload) {
-    commit('submitting', payload)
+    let timer = getters.getTimer
+    if (timer) {
+      clearTimeout(timer)
+    }
+    timer = setTimeout(() => {
+      commit('submitting', payload)
+    }, 333)
+    commit('setValue', { key: 'timer', value: timer })
   },
   setValue({ commit }, payload) {
     commit('setValue', payload)

--- a/src/vuex/submit.js
+++ b/src/vuex/submit.js
@@ -6,6 +6,8 @@ const getDefaultState = () => ({
   timer: null,
 })
 
+const DELAY = 333
+
 const state = getDefaultState()
 
 const getters = {
@@ -14,14 +16,19 @@ const getters = {
 }
 
 const actions = {
-  setSubmitting({ commit }, payload) {
-    let timer = getters.getTimer
+  setSubmitting({ commit, state }, payload) {
+    let timer = state.timer
     if (timer) {
       clearTimeout(timer)
+      commit('setValue', { key: 'timer', value: null })
+    }
+    if (payload === false) {
+      commit('submitting', payload)
+      return
     }
     timer = setTimeout(() => {
       commit('submitting', payload)
-    }, 333)
+    }, DELAY)
     commit('setValue', { key: 'timer', value: timer })
   },
   setValue({ commit }, payload) {

--- a/src/vuex/submit.js
+++ b/src/vuex/submit.js
@@ -1,0 +1,44 @@
+// Vuex module for tracking submitting state
+// Namespaced to prevent collisions
+
+const getDefaultState = () => ({
+  submitting: false,
+})
+
+const state = getDefaultState()
+
+const getters = {
+  isSubmitting: (state) => state.submitting,
+}
+
+const actions = {
+  setSubmitting({ commit }, payload) {
+    commit('submitting', payload)
+  },
+  setValue({ commit }, payload) {
+    commit('setValue', payload)
+  },
+  clearAllFields({ commit }) {
+    commit('resetState')
+  },
+}
+
+const mutations = {
+  submitting(state, payload) {
+    state.submitting = payload
+  },
+  setValue(state, { key, value }) {
+    state[key] = value
+  },
+  resetState(state) {
+    Object.assign(state, getDefaultState())
+  },
+}
+
+export default {
+  namespaced: true,
+  state,
+  getters,
+  actions,
+  mutations,
+}


### PR DESCRIPTION
This PR moves the overlay/spinner combo to the `IFXPageHeader` component as this component is in more pages than `IFXPageActionBar`, especially pages that don't use the action bar. In addition, the `z-index` is set to 300 to have the overlay appear over dialog boxes.

There is also add a new Vuex module containing the `submitting` state variable; this is set/clear via a Vuex action, `setSubmitting` which takes a `true` or `false`. To prevent any quick flashes of the overlay, the action will wait 1/3 second before `commit`ing the change. Should a new request to set the state variable to `true` come in, we will clear the current timer and start a new one; requests to set the state variable to `false` take effect immediately.

The previous method of passing state into `IFXPageActionBar` has been removed; now the `submitSave` and `saveUpdate` functions use the action to set/clear the state.

To use this in other pages, first map the Vuex action with and then call the action with the appropriate payload:

```
...mapActions(['submit/setSubmitting'])
   .
   .
   .
this.$store.dispatch('submit/setSubmitting', true) // Display overlay in 1/3 second
```
Since we’re often mapping `showMessage` anyway, this can be combined as
`...mapActions(['showMessage', 'submit/setSubmitting'])`


