### PR TITLE
Remove the need for an authorization to show inactive strikethrough

### DIFF
--- a/src/components/contact/IFXAffiliationRoleDisplayEdit.vue
+++ b/src/components/contact/IFXAffiliationRoleDisplayEdit.vue
@@ -69,11 +69,7 @@ export default {
       </span>
       <span class="ml-2">of {{ affiliation.organization | orgNameFromSlug }}</span>
     </v-col>
-    <v-col
-      md="8"
-      v-else
-      :class="{ 'text-decoration-line-through': $api.auth.can('see-inactive-affiliations') && !itemLocal.active }"
-    >
+    <v-col md="8" v-else :class="{ 'text-decoration-line-through': !itemLocal.active }">
       <span>{{ affiliation.role | affiliationRoleDisplay }} of {{ affiliation.organization | orgNameFromSlug }}</span>
     </v-col>
     <v-col v-if="$api.auth.can('edit-affiliations')" md="4">


### PR DESCRIPTION
This PR removes the `see-inactive-affiliations` authorization from the code that determines how to display inactive roles in the _Other Affiliations_ section. Now it will always show a strikethrough for those roles.
