### PR TITLE
Use tinyMCE 6.8.4

### DIFF
--- a/src/components/IFXTextEditor.vue
+++ b/src/components/IFXTextEditor.vue
@@ -1,7 +1,8 @@
 <template>
   <Editor
-    v-model='text'
+    v-model="text"
     :init="init"
+    tinymceScriptSrc="https://cdnjs.cloudflare.com/ajax/libs/tinymce/6.8.4/tinymce.min.js"
   ></Editor>
 </template>
 
@@ -15,7 +16,7 @@ export default {
   name: 'IFXTextEditor',
   // extends: VInput,
   components: {
-    Editor
+    Editor,
   },
   props: {
     value: null,
@@ -29,7 +30,7 @@ export default {
   methods: {
     initCallback() {
       this.isLoading = false
-    }
+    },
   },
   computed: {
     init() {
@@ -37,14 +38,13 @@ export default {
         height: 300,
         menubar: false,
         statusbar: false,
-        plugins: [
-          'advlist autolink lists link image charmap',
-          'searchreplace visualblocks code fullscreen',
-          'print preview anchor insertdatetime media',
-          'paste code help wordcount table'
-        ],
-        toolbar: 'undo redo | formatselect | bold italic | alignleft aligncenter alignright | bullist numlist outdent indent | help',
-        setup: editor => { editor.on('init', () => this.initCallback()) }
+        plugins:
+          'advlist autolink lists link image charmap searchreplace visualblocks fullscreen preview anchor insertdatetime media code help wordcount table',
+        toolbar:
+          'undo redo | blocks fontfamily fontsize | bold italic | alignleft aligncenter alignright | bullist numlist outdent indent | help',
+        setup: (editor) => {
+          editor.on('init', () => this.initCallback())
+        },
       }
     },
   },
@@ -53,13 +53,13 @@ export default {
   },
   mounted() {
     this.content = this.value
-  }
+  },
 }
 </script>
 
 <style>
-  /* TODO: register domain */
-  .tox-notifications-container {
-    display: none !important;
-  }
+/* TODO: register domain */
+.tox-notifications-container {
+  display: none !important;
+}
 </style>

--- a/src/components/mailing/IFXMailingCompose.vue
+++ b/src/components/mailing/IFXMailingCompose.vue
@@ -53,17 +53,17 @@ export default {
     labManagerOrgSlugs: {
       type: Array,
       required: false,
-      default: null
+      default: null,
     },
     recipients: {
       type: String,
       required: false,
-      default: null
+      default: null,
     },
     recipientField: {
       type: String,
       required: false,
-      default: null
+      default: null,
     },
   },
   data() {
@@ -76,7 +76,7 @@ export default {
         cc: null,
         bcc: null,
         subject: null,
-        message: null
+        message: null,
       },
       fromAddr: null,
       toList: [],
@@ -95,7 +95,9 @@ export default {
       let result = str
       if (str && str.indexOf('<') !== -1) {
         const match = str.match(/<\s*([^ >]+)\s*>/)
-        if (match) { result = match[1] }
+        if (match) {
+          result = match[1]
+        }
       }
       return result
     },
@@ -111,7 +113,7 @@ export default {
         message: this.content,
         subject: this.localSubject,
         fromstr: this.fromAddr,
-        tostr: [...new Set(this.toList.map(toMailStr))].join(',')
+        tostr: [...new Set(this.toList.map(toMailStr))].join(','),
       }
       if (this.ccList.length) {
         mailing.ccstr = [...new Set(this.ccList.map(toMailStr))].join(',')
@@ -119,9 +121,10 @@ export default {
       if (this.bccList.length) {
         mailing.bccstr = [...new Set(this.bccList.map(toMailStr))].join(',')
       }
-      this.$api.mailing.sendIfxMailing(mailing)
-        .then(res => this.showMessage(res))
-        .catch(err => {
+      this.$api.mailing
+        .sendIfxMailing(mailing)
+        .then((res) => this.showMessage(res))
+        .catch((err) => {
           if (has(err, 'response') && has(err.response, 'data') && has(err.response.data, 'field_errors')) {
             this.fieldErrors = err.response.data.field_errors
           } else {
@@ -136,13 +139,10 @@ export default {
         height: 300,
         menubar: false,
         statusbar: false,
-        plugins: [
-          'advlist autolink lists link image charmap',
-          'searchreplace visualblocks fullscreen',
-          'print preview anchor insertdatetime media',
-          'paste code help wordcount table'
-        ],
-        toolbar: 'undo redo | code | formatselect | bold italic | alignleft aligncenter alignright | bullist numlist outdent indent | help',
+        plugins:
+          'advlist autolink lists link image charmap searchreplace visualblocks fullscreen preview anchor insertdatetime media code help wordcount table',
+        toolbar:
+          'undo redo | code | blocks fontfamily fontsize | bold italic | alignleft aligncenter alignright | bullist numlist outdent indent | help',
       }
     },
   },
@@ -154,17 +154,19 @@ export default {
     if (this.subject) {
       this.localSubject = this.subject
     }
-    this.$api.contactables.getList()
+    this.$api.contactables
+      .getList()
       .then((result) => {
         this.contactables = result
         // If we're doing the lab manager notification thing
         if (this.labManagerOrgSlugs) {
-          this.$api.contactables.getList({ role: 'Lab Manager', org_slugs: this.labManagerOrgSlugs })
+          this.$api.contactables
+            .getList({ role: 'Lab Manager', org_slugs: this.labManagerOrgSlugs })
             .then((result2) => {
               // If a contact for one of the orgs cannot be found, raise an error
               const orgContactNotFound = []
               me.labManagerOrgSlugs.forEach((slug) => {
-                const name = this.$api.organization.parseSlug((slug)).name
+                const name = this.$api.organization.parseSlug(slug).name
                 // Check if org name is in the contactable label
                 if (!result2.some((contactable) => contactable.label.indexOf(name) !== -1)) {
                   orgContactNotFound.push(name)
@@ -210,13 +212,11 @@ export default {
             if (matches) {
               this.toList = this.toList.concat(matches)
             } else {
-              this.toList.push(
-                {
-                  detail: email,
-                  label: email,
-                  text: email
-                }
-              )
+              this.toList.push({
+                detail: email,
+                label: email,
+                text: email,
+              })
             }
           })
         }
@@ -227,13 +227,11 @@ export default {
             if (matches) {
               this.ccList = this.ccList.concat(matches)
             } else {
-              this.ccList.push(
-                {
-                  detail: email,
-                  label: email,
-                  text: email
-                }
-              )
+              this.ccList.push({
+                detail: email,
+                label: email,
+                text: email,
+              })
             }
           })
         }
@@ -244,13 +242,11 @@ export default {
             if (matches) {
               this.bccList = this.bccList.concat(matches)
             } else {
-              this.bccList.push(
-                {
-                  detail: email,
-                  label: email,
-                  text: email
-                }
-              )
+              this.bccList.push({
+                detail: email,
+                label: email,
+                text: email,
+              })
             }
           })
         }
@@ -281,16 +277,17 @@ export default {
           })
         }
       })
-      .catch((error) => { this.showMessage(error) })
+      .catch((error) => {
+        this.showMessage(error)
+      })
     if (this.messageName) {
-      this.$api.message.getList({ name: this.messageName })
-        .then((result) => {
-          if (result.length) {
-            this.content = result[0].message
-          }
-        })
+      this.$api.message.getList({ name: this.messageName }).then((result) => {
+        if (result.length) {
+          this.content = result[0].message
+        }
+      })
     }
-  }
+  },
 }
 </script>
 
@@ -301,58 +298,55 @@ export default {
       <template #content>Compose a new mailing</template>
     </IFXPageHeader>
     <v-container>
-    <v-form v-model='isValid' id="mailing-compose-form" ref="mailingComposeForm">
-      <v-text-field
-        label="From"
-        v-model="fromAddr"
-        :rules="formRules.generic"
-        :error-messages="fieldErrors.fromAddr"
-        class="required"
-      ></v-text-field>
-      <IFXContactablesCombobox
-        ref="toCombobox"
-        label="To:"
-        required
-        :fieldError="fieldErrors.toList"
-        v-model="toList"
-        :contactables="contactables"
-      />
-      <IFXContactablesCombobox
-        ref="ccCombobox"
-        label="Cc:"
-        :fieldError="fieldErrors.ccList"
-        v-model="ccList"
-        :contactables="contactables"
-      />
-      <IFXContactablesCombobox
-        label="Bcc:"
-        :fieldError="fieldErrors.bccList"
-        v-model="bccList"
-        :contactables="contactables"
-      />
-      <v-text-field
-        label="Subject"
-        v-model="localSubject"
-        :rules="formRules.generic"
-        :error-messages="fieldErrors.subject"
-        required
-        class="required"
-        hint="This will appear as the subject line in the email."
-      ></v-text-field>
-      <span>
-        <Editor
-          v-model="content"
-          :init="editorInit"
-        ></Editor>
-      </span>
-    </v-form>
-    <IFXPageActionBar
-      :disabled='false'
-      btnType='submit'
-      btnText='Send'
-      @action="sendMailing"
-    >
-    </IFXPageActionBar>
+      <v-form v-model="isValid" id="mailing-compose-form" ref="mailingComposeForm">
+        <v-text-field
+          label="From"
+          v-model="fromAddr"
+          :rules="formRules.generic"
+          :error-messages="fieldErrors.fromAddr"
+          class="required"
+        ></v-text-field>
+        <IFXContactablesCombobox
+          ref="toCombobox"
+          label="To:"
+          required
+          :fieldError="fieldErrors.toList"
+          v-model="toList"
+          :contactables="contactables"
+        />
+        <IFXContactablesCombobox
+          ref="ccCombobox"
+          label="Cc:"
+          :fieldError="fieldErrors.ccList"
+          v-model="ccList"
+          :contactables="contactables"
+        />
+        <IFXContactablesCombobox
+          label="Bcc:"
+          :fieldError="fieldErrors.bccList"
+          v-model="bccList"
+          :contactables="contactables"
+        />
+        <v-text-field
+          label="Subject"
+          v-model="localSubject"
+          :rules="formRules.generic"
+          :error-messages="fieldErrors.subject"
+          required
+          class="required"
+          hint="This will appear as the subject line in the email."
+        ></v-text-field>
+        <span>
+          <Editor
+            v-model="content"
+            :init="editorInit"
+            tinymceScriptSrc="https://cdnjs.cloudflare.com/ajax/libs/tinymce/6.8.4/tinymce.min.js"
+          ></Editor>
+        </span>
+      </v-form>
+      <div class="mt-3">
+        <IFXPageActionBar :disabled="false" btnType="submit" btnText="Send" @action="sendMailing"></IFXPageActionBar>
+      </div>
     </v-container>
   </v-container>
 </template>

--- a/src/components/message/IFXMessageCreateEdit.vue
+++ b/src/components/message/IFXMessageCreateEdit.vue
@@ -20,14 +20,11 @@ export default {
         height: 300,
         menubar: false,
         statusbar: false,
-        plugins: [
-          'advlist autolink lists link image charmap',
-          'searchreplace visualblocks fullscreen',
-          'print preview anchor insertdatetime media',
-          'paste code help wordcount table',
-        ],
+        plugins:
+          'advlist autolink lists link image charmap searchreplace visualblocks fullscreen preview anchor insertdatetime media code help wordcount table',
         toolbar:
-          'undo redo | code | formatselect | bold italic | alignleft aligncenter alignright | bullist numlist outdent indent | help',
+          'undo redo | code | blocks fontfamily fontsize | bold italic | alignleft aligncenter alignright | bullist numlist outdent indent | help',
+        quickbars_selection_toolbar: 'bold italic | quicklink h2 h3 blockquote',
       }
     },
     messageTitle() {
@@ -70,7 +67,11 @@ export default {
         </v-row>
         <v-row>
           <v-col>
-            <Editor v-model="item.message" :init="editorInit"></Editor>
+            <Editor
+              v-model="item.message"
+              :init="editorInit"
+              tinymceScriptSrc="https://cdnjs.cloudflare.com/ajax/libs/tinymce/6.8.4/tinymce.min.js"
+            ></Editor>
           </v-col>
         </v-row>
         <v-row>


### PR DESCRIPTION
This PR uses an external CDN hosting `tinyMCE` 6.8.4 rather than using the default `tiny.cloud` version, which is now 7.x and requires an API key. 6.8.4 is MIT licensed so we can use it with no fee or license issues. Also changed toolbar to use `blocks fontfamily and fontsize` replacing `selectformat` which is apparently no longer supports.  Removed deprecated plugins `paste` and `print` that are bundled into Core capability.

Note that 6.8.4 is supported until sometime in 2025. We may have to deal with API keys and pricing in the future.