### PR TITLE
Show errors from a save/update on the main part of the `IFXUserDetail` page

### DIFF
--- a/src/components/item/IFXItemEditableDetailMixin.js
+++ b/src/components/item/IFXItemEditableDetailMixin.js
@@ -64,15 +64,15 @@ export default {
       })
       this.apiRef
         .update(this.item)
-        .then(async (res) => {
+        .then(async () => {
           this.submitting = false
           const message = `${this.itemType} updated successfully.`
           this.showMessage(message)
-          await this.sleep(this.routeDelay)
           if (this.$route.query.next) {
+            await this.sleep(this.routeDelay)
             this.$router.push({ path: this.$route.query.next })
           } else {
-            this.rtr.push({ name: this.itemDetail, params: { id: res.data.id }, query: { t: new Date().getTime() } })
+            this.getItem()
           }
         })
         .catch((error) => {

--- a/src/components/item/IFXItemEditableDetailMixin.js
+++ b/src/components/item/IFXItemEditableDetailMixin.js
@@ -72,7 +72,7 @@ export default {
             await this.sleep(this.routeDelay)
             this.$router.push({ path: this.$route.query.next })
           } else {
-            this.getItem()
+            this.init()
           }
         })
         .catch((error) => {

--- a/src/components/user/IFXUserDetail.vue
+++ b/src/components/user/IFXUserDetail.vue
@@ -223,6 +223,29 @@ export default {
       </template>
     </IFXPageHeader>
     <v-container>
+      <v-row dense v-if="Object.keys(this.errors).length">
+        <v-col>
+          <v-alert elevation="2" dense colored-border border="left" color="error" icon="mdi-alert-circle-outline">
+            <v-row dense>
+              <v-col>
+                <h3 class="font-weight-medium">Please correct the following errors</h3>
+              </v-col>
+            </v-row>
+            <v-row dense>
+              <v-col>
+                <ul>
+                  <li v-for="(error, key) in errors" :key="key">
+                    {{ key }}:
+                    <span v-for="errorText in error" :key="errorText">
+                      {{ errorText }}
+                    </span>
+                  </li>
+                </ul>
+              </v-col>
+            </v-row>
+          </v-alert>
+        </v-col>
+      </v-row>
       <v-row dense>
         <v-col sm="12" md="6">
           <v-row dense wrap>

--- a/src/components/user/IFXUserInfoEdit.vue
+++ b/src/components/user/IFXUserInfoEdit.vue
@@ -113,7 +113,7 @@ export default {
               :rules="formRules.generic"
               required
             ></v-text-field>
-            <v-combobox
+            <v-autocomplete
               v-if="canEdit('User.groups')"
               v-model="itemLocal.groups"
               :items="allGroupNames"
@@ -123,13 +123,14 @@ export default {
               hint="Groups to which this user belongs."
               persistent-hint
               :error-messages="errors.groups"
+              @focus="clearError('groups')"
             >
               <template #selection="{ item }">
                 <v-chip :color="getChipColorForGroup(item)" close @click:close="removeGroup(item)">
                   <strong>{{ item }}</strong>
                 </v-chip>
               </template>
-            </v-combobox>
+            </v-autocomplete>
             <div class="items-warning" v-else>{{ itemLocal.groups.join(', ') || 'No groups' }}</div>
           </v-col>
         </v-row>


### PR DESCRIPTION
This PR shows errors on the main part of the `IFXUserDetail` page as well as under the form elements where they occurred. This is needed because the dialog for changing user info items isn't normally shown so the user won't know which element caused the issue. 

Also, we now just re-initialize the data for successful updates rather than redirecting to the same detail page. The `groups` form element was changed from a `v-combobox` to a `v-autocomplete` as the user shouldn't be able to add new groups that way.
