### PR TITLE
Fix rank sort order

### DIFF
--- a/src/api/IFXAPI.js
+++ b/src/api/IFXAPI.js
@@ -418,56 +418,56 @@ export default class IFXAPIService {
     const api = this.genericAPI(baseUrl, null, createFunc, decomposeFunc)
     api.validRanks = [
       {
-        value: 'school',
-        text: 'School',
+        value: 'center',
+        text: 'Center',
+      },
+      {
+        value: 'company',
+        text: 'Company',
       },
       {
         value: 'department',
         text: 'Department',
       },
       {
-        value: 'center',
-        text: 'Center',
-      },
-      {
-        value: 'lab',
-        text: 'Laboratory',
-      },
-      {
-        value: 'institute',
-        text: 'Institute',
-      },
-      {
-        value: 'museum',
-        text: 'Museum',
-      },
-      {
-        value: 'institution',
-        text: 'Institution',
+        value: 'division',
+        text: 'Division',
       },
       {
         value: 'facility',
         text: 'Facility',
       },
       {
-        value: 'program',
-        text: 'Program',
-      },
-      {
-        value: 'division',
-        text: 'Division',
-      },
-      {
         value: 'group',
         text: 'Group',
+      },
+      {
+        value: 'institute',
+        text: 'Institute',
+      },
+      {
+        value: 'institution',
+        text: 'Institution',
+      },
+      {
+        value: 'lab',
+        text: 'Laboratory',
+      },
+      {
+        value: 'museum',
+        text: 'Museum',
       },
       {
         value: 'office',
         text: 'Office',
       },
       {
-        value: 'company',
-        text: 'Company',
+        value: 'program',
+        text: 'Program',
+      },
+      {
+        value: 'school',
+        text: 'School',
       },
     ]
     api.getValidRankByValue = (value) => api.validRanks.find((r) => r.value === value)

--- a/src/components/organization/IFXOrganizationCreateEdit.vue
+++ b/src/components/organization/IFXOrganizationCreateEdit.vue
@@ -31,7 +31,7 @@ export default {
     async init() {
       this.item = await this.getItem()
       if (!this.item.id) {
-        this.item.orgTree = 'Local'
+        this.item.orgTree = 'Harvard'
       }
       this.cachedItem = JSON.stringify(this.apiRef.decompose(this.item))
       this.allUsers = await this.$api.user.getList()
@@ -57,19 +57,12 @@ export default {
       return !!this.item.ifxOrg
     },
     title() {
-      let rank = this.item.rank
-      this.apiRef.validRanks.forEach((rankData) => {
-        if (rankData.value === this.item.rank) {
-          rank = rankData.text
-        }
-      })
-      return `${this.item.name} (a ${this.item.orgTree} ${rank})`
+      return `${this.item.name} (a ${this.item.orgTree} ${this.item.rank})`
     },
     orgTreeRules() {
       return [
-        this.formRules.generic,
-        (v) => !v || v.toLowerCase() !== 'harvard' || "'Harvard' is a protected tree",
-      ].flat()
+        (v) => !v || 'Org tree is required',
+      ]
     },
   },
 }
@@ -92,7 +85,7 @@ export default {
               :rules="formRules.generic"
               :error-messages="errors.name"
               required
-              :disabled="isIfxOrg"
+              class="required"
             ></v-text-field>
           </v-col>
           <v-col>
@@ -106,7 +99,7 @@ export default {
               item-text="text"
               item-value="value"
               required
-              :disabled="isIfxOrg"
+              class="required"
             ></v-select>
           </v-col>
           <v-col>
@@ -114,14 +107,14 @@ export default {
               v-model="item.orgTree"
               label="Org tree"
               data-cy="org-tree"
-              :rules="orgTreeRules"
+              :rules="formRules.generic"
               :error-messages="errors.org_tree"
               required
-              :disabled="isIfxOrg"
+              class="required"
             ></v-text-field>
           </v-col>
         </v-row>
-        <v-row>
+        <v-row v-if="item.id">
           <v-col>
             <IFXItemSelectList title="Users" :items.sync="item.users" :getEmptyItem="$api.organizationUser.create">
               <template v-slot="{ item }">
@@ -130,7 +123,7 @@ export default {
             </IFXItemSelectList>
           </v-col>
         </v-row>
-        <v-row>
+        <v-row v-if="item.id">
           <v-col>
             <IFXItemSelectList
               title="Contacts"

--- a/src/components/request/IFXAccountRequestTrackDetail.vue
+++ b/src/components/request/IFXAccountRequestTrackDetail.vue
@@ -13,6 +13,7 @@ import DisplayExpenseCode from './IFXDisplayExpenseCode'
 import DisplayTermsAndConditions from './IFXDisplayTermsAndConditions'
 import DisplayAffiliations from './IFXDisplayAffiliations'
 import DisplayEnteredAffiliation from './IFXDisplayEnteredAffiliation'
+import DisplaySimpleText from './IFXDisplaySimpleText'
 
 export default {
   name: 'IFXAccountRequestTrackDetail',
@@ -37,6 +38,7 @@ export default {
     DisplayTermsAndConditions,
     DisplayAffiliations,
     DisplayEnteredAffiliation,
+    DisplaySimpleText,
   },
   data() {
     return {
@@ -70,7 +72,7 @@ export default {
           </v-flex>
           <v-flex xs12 md9 v-if="accountRequestData.tracks[track].fields[field].display_component">
             <component
-              v-if="['harvard_key', 'project', 'scientific_area', 'expense_code', 'terms_and_conditions'].includes(field)"
+              v-if="['harvard_key', 'project', 'scientific_area', 'expense_code', 'terms_and_conditions', 'nnin_admin_username'].includes(field)"
               :is="accountRequestData.tracks[track].fields[field].display_component"
               :data="accountRequestData[field]"
             ></component>

--- a/src/components/request/IFXDisplaySimpleText.vue
+++ b/src/components/request/IFXDisplaySimpleText.vue
@@ -1,0 +1,17 @@
+<script>
+export default {
+  name: 'IFXDisplayHarvardKey',
+  props: ['data'],
+}
+</script>
+<template>
+  <v-layout column>
+    <v-flex v-if="data">
+      {{ data }}
+    </v-flex>
+    <v-flex v-else>
+      ???
+    </v-flex>
+  </v-layout>
+</template>
+<style scoped></style>

--- a/src/components/user/IFXUserDetail.vue
+++ b/src/components/user/IFXUserDetail.vue
@@ -381,7 +381,7 @@ export default {
                   <span class="ml-1">{{ category }}s</span>
                 </summary>
                 <div v-for="file in userCategories[category]" :key="`${category}${file.id}`" class="ml-4">
-                  <a :href="file.file" target="_blank">{{ file.file }}</a>
+                  <a :href="file.file" target="_blank">{{ file.file | fileNameFromUrl }}</a>
                 </div>
               </details>
             </div>

--- a/src/entrypoint.js
+++ b/src/entrypoint.js
@@ -156,6 +156,7 @@ import IFXDisplayExpenseCode from '@/components/request/IFXDisplayExpenseCode'
 import IFXDisplayTermsAndConditions from '@/components/request/IFXDisplayTermsAndConditions'
 import IFXDisplayAffiliations from '@/components/request/IFXDisplayAffiliations'
 import IFXDisplayEnteredAffiliation from '@/components/request/IFXDisplayEnteredAffiliation'
+import IFXDisplaySimpleText from '@/components/request/IFXDisplaySimpleText'
 import IFXRequestCommentList from '@/components/request/IFXRequestCommentList'
 import IFXRequestList from '@/components/request/IFXRequestList'
 
@@ -264,6 +265,7 @@ export {
   IFXDisplayTermsAndConditions,
   IFXDisplayAffiliations,
   IFXDisplayEnteredAffiliation,
+  IFXDisplaySimpleText,
   IFXRequestCommentList,
   IFXRequestList,
   IFXLabBillingSummaryList,

--- a/src/filters/IFXFilters.js
+++ b/src/filters/IFXFilters.js
@@ -133,6 +133,13 @@ export function orgNameFromSlug(slug) {
   return result
 }
 
+export function fileNameFromUrl(url) {
+  if (!url) return '';
+
+  // Split the URL by '/' and return the last element
+  return url.split('/').pop();
+}
+
 export default {
   humanDatetime,
   centsToDollars,
@@ -144,4 +151,5 @@ export default {
   affiliationRoleDisplay,
   commaSpace,
   orgNameFromSlug,
+  fileNameFromUrl,
 }


### PR DESCRIPTION
Add a generic display component to help out with things like nnin admin username 
Allow Harvard organizations to be created to support new organizations that must be setup for external users of NICE, BauerCAT 
New filter that displays file name only for user file links. 
Slightly different formatting for demographic data, etc.