### PR TITLE
Add Billing Summaries to Billing Record Summary page

### DIFF
--- a/src/api/IFXAPI.js
+++ b/src/api/IFXAPI.js
@@ -18,6 +18,9 @@ import BillingRecord, { BillingTransaction } from '@/components/billingRecord/IF
 import { Product, ProductRate, Processing } from '@/components/product/IFXProduct'
 import ProductUsage from '@/components/productUsage/IFXProductUsage'
 import { ReportRun, Report } from '@/components/report/IFXReport'
+import AccountBillingSummary from '@/components/billingSummary/IFXAccountBillingSummary'
+import UserBillingSummary from '@/components/billingSummary/IFXUserBillingSummary'
+import ProductRateBillingSummary from '@/components/billingSummary/IFXProductRateBillingSummary'
 
 function isNumeric(val) {
   return !Number.isNaN(parseFloat(val)) && Number.isFinite(val)
@@ -1018,6 +1021,41 @@ export default class IFXAPIService {
       data.ifxids = ifxids
     }
     return this.axios.post(url, data, { headers: { 'Content-Type': 'application/json' } })
+  }
+
+  get accountBillingSummary() {
+    const baseURL = this.urls.GET_SUMMARY_BY_ACCOUNT
+    const createFunc = (accountBillingSummaryData, decompose = false) => {
+      const newAccountBillingSummaryData = cloneDeep(accountBillingSummaryData) || {}
+      // If decomposing, do not create a new object
+      return decompose ? newAccountBillingSummaryData : new AccountBillingSummary(newAccountBillingSummaryData)
+    }
+    const decomposeFunc = (newAccountBillingSummaryData) => createFunc(newAccountBillingSummaryData, true)
+    return this.genericAPI(baseURL, AccountBillingSummary, createFunc, decomposeFunc)
+  }
+
+  get userBillingSummary() {
+    const baseURL = this.urls.GET_SUMMARY_BY_USER
+    const createFunc = (userBillingSummaryData, decompose = false) => {
+      const newUserBillingSummaryData = cloneDeep(userBillingSummaryData) || {}
+      // If decomposing, do not create a new object
+      return decompose ? newUserBillingSummaryData : new UserBillingSummary(newUserBillingSummaryData)
+    }
+    const decomposeFunc = (newUserBillingSummaryData) => createFunc(newUserBillingSummaryData, true)
+    return this.genericAPI(baseURL, UserBillingSummary, createFunc, decomposeFunc)
+  }
+
+  get productRateBillingSummary() {
+    const baseURL = this.urls.GET_SUMMARY_BY_PRODUCT_RATE
+    const createFunc = (productRateBillingSummaryData, decompose = false) => {
+      const newProductRateBillingSummaryData = cloneDeep(productRateBillingSummaryData) || {}
+      // If decomposing, do not create a new object
+      return decompose
+        ? newProductRateBillingSummaryData
+        : new ProductRateBillingSummary(newProductRateBillingSummaryData)
+    }
+    const decomposeFunc = (newProductRateBillingSummaryData) => createFunc(newProductRateBillingSummaryData, true)
+    return this.genericAPI(baseURL, ProductRateBillingSummary, createFunc, decomposeFunc)
   }
 
   getLabChargeHistory(facility, startMonth, startYear, endMonth, endYear) {

--- a/src/components/billingRecord/IFXBillingRecordHeaderDecimal.vue
+++ b/src/components/billingRecord/IFXBillingRecordHeaderDecimal.vue
@@ -38,10 +38,6 @@ export default {
       type: Number,
       required: true,
     },
-    getSummaryDetails: {
-      type: Function,
-      required: true,
-    },
   },
   mounted() {
     this.localRowSelectionToggle = this.rowSelectionToggle.concat()
@@ -49,9 +45,6 @@ export default {
   data() {
     return {
       localRowSelectionToggle: [],
-      showSummaryDetail: false,
-      summaryButtonText: 'Show',
-      summaryDetails: [],
     }
   },
   computed: {},
@@ -60,13 +53,6 @@ export default {
       this.$emit('update:row-selection-toggle', this.localRowSelectionToggle)
       this.$emit('update:row-selection-toggle-indeterminate', this.rowSelectionToggleIndeterminateGroup)
       this.toggleGroup(this.group)
-    },
-    toggleSummaryDetail() {
-      this.summaryButtonText = this.showSummaryDetail ? 'Show' : 'Hide'
-      if (!this.showSummaryDetail && this.summaryDetails.length === 0) {
-        this.summaryDetails = Array.from(this.getSummaryDetails(this.group).entries())
-      }
-      this.showSummaryDetail = !this.showSummaryDetail
     },
   },
   watch: {},
@@ -93,16 +79,7 @@ export default {
           {{ $api.organization.parseSlug(group).name }}
         </span>
         <span class="ml-3 font-weight-medium">Total charges: {{ summaryCharges | dollars }}</span>
-        <v-btn small text @click="toggleSummaryDetail" class="ml-2">{{ summaryButtonText }} Acct Summary</v-btn>
       </div>
-    </v-row>
-    <v-row v-if="showSummaryDetail">
-      <v-col class="py-1 ml-9">
-        <v-row v-for="entry in summaryDetails" :key="`${group}-${entry[0]}`" class="text-body-2">
-          <v-col cols="5" class="ml-3">{{ entry[0] }}</v-col>
-          <v-col class="text-xs-left ml-3 font-weight-medium">{{ entry[1] | dollars }}</v-col>
-        </v-row>
-      </v-col>
     </v-row>
   </td>
 </template>

--- a/src/components/billingRecord/IFXBillingRecordListDecimal.vue
+++ b/src/components/billingRecord/IFXBillingRecordListDecimal.vue
@@ -129,7 +129,13 @@ export default {
         { text: 'Lab', value: 'account.organization', sortable: true },
         { text: 'Expense Code / PO', value: 'account.slug', sortable: true },
         { text: 'Product', value: 'product', sortable: true },
-        { text: 'Start Date', value: 'startDate', sortable: true, hide: !this.showDates && !this.showStartDate, namedSlot: true },
+        {
+          text: 'Start Date',
+          value: 'startDate',
+          sortable: true,
+          hide: !this.showDates && !this.showStartDate,
+          namedSlot: true,
+        },
         { text: 'End Date', value: 'endDate', sortable: true, hide: !this.showDates, namedSlot: true },
         { text: 'Charge', value: 'decimalCharge', sortable: true, width: '100px' },
         { text: 'Percent', value: 'percent', sortable: true, width: '100px' },
@@ -482,20 +488,6 @@ export default {
       const records = this.filteredItems.filter((item) => item.account.organization === group)
       const summary = records.reduce((prev, current) => prev + current.decimalCharge, 0)
       return summary
-    },
-    getSummaryDetails(group) {
-      const records = this.filteredItems.filter((item) => item.account.organization === group)
-      const expenseMap = new Map()
-      records.forEach((item) => {
-        const charge = item.decimalCharge
-        if (expenseMap.has(item.account.slug)) {
-          const value = expenseMap.get(item.account.slug)
-          expenseMap.set(item.account.slug, value + charge)
-        } else {
-          expenseMap.set(item.account.slug, charge)
-        }
-      })
-      return expenseMap
     },
     totalCharges() {
       const total = this.filteredItems.reduce((prev, current) => prev + current.decimalCharge, 0)
@@ -1127,7 +1119,6 @@ export default {
                 :rowSelectionToggleIndeterminateGroup.sync="rowSelectionToggleIndeterminate[group]"
                 :summaryCharges="summaryCharges(group)"
                 :toggleGroup="toggleGroup"
-                :getSummaryDetails="getSummaryDetails"
                 @
               />
             </template>

--- a/src/components/billingRecord/IFXBillingRecords.vue
+++ b/src/components/billingRecord/IFXBillingRecords.vue
@@ -201,7 +201,14 @@ export default {
                   :headers="[
                     { text: 'Account Name', value: 'name', sortable: true },
                     { text: 'Expense Code / PO', value: 'code', sortable: true },
-                    { text: 'Charges', value: 'totalDecimalCharge', sortable: true, namedSlot: true, align: 'end' },
+                    {
+                      text: 'Charges',
+                      value: 'totalDecimalCharge',
+                      sortable: true,
+                      namedSlot: true,
+                      width: '20rem',
+                      align: 'end',
+                    },
                   ]"
                 />
               </v-tab-item>
@@ -214,7 +221,14 @@ export default {
                   apiString="userBillingSummary"
                   :headers="[
                     { text: 'User', value: 'productUserFullName', sortable: true },
-                    { text: 'Charges', value: 'totalDecimalCharge', sortable: true, namedSlot: true, align: 'end' },
+                    {
+                      text: 'Charges',
+                      value: 'totalDecimalCharge',
+                      sortable: true,
+                      namedSlot: true,
+                      width: '20rem',
+                      align: 'end',
+                    },
                   ]"
                 />
               </v-tab-item>
@@ -225,10 +239,18 @@ export default {
                   :year="getYear()"
                   itemType="genericBillingSummary"
                   apiString="productRateBillingSummary"
+                  :extraParams="{ facility: facility.name }"
                   :headers="[
                     { text: 'Product', value: 'productName', sortable: true },
                     { text: 'Rate', value: 'rateName', sortable: true },
-                    { text: 'Charges', value: 'totalDecimalCharge', sortable: true, namedSlot: true, align: 'end' },
+                    {
+                      text: 'Charges',
+                      value: 'totalDecimalCharge',
+                      sortable: true,
+                      namedSlot: true,
+                      width: '20rem',
+                      align: 'end',
+                    },
                   ]"
                 />
               </v-tab-item>

--- a/src/components/billingRecord/IFXBillingRecords.vue
+++ b/src/components/billingRecord/IFXBillingRecords.vue
@@ -2,6 +2,7 @@
 import moment from 'moment'
 import { mapActions } from 'vuex'
 import IFXBillingRecordListDecimal from '@/components/billingRecord/IFXBillingRecordListDecimal'
+import IFXGenericBillingSummaryList from '@/components/billingSummary/IFXGenericBillingSummaryList'
 
 export default {
   name: 'IFXBillingRecords',
@@ -63,6 +64,7 @@ export default {
       itemKey: 'key',
       showBillingRecords: false,
       keyModifier: 1,
+      currentTab: 0,
       actions: [
         {
           key: 'approve',
@@ -77,6 +79,7 @@ export default {
   },
   components: {
     IFXBillingRecordListDecimal,
+    IFXGenericBillingSummaryList,
   },
   methods: {
     ...mapActions(['showMessage']),
@@ -102,6 +105,12 @@ export default {
       this.showBillingRecords = false
       this.keyModifier += 100
       this.showBillingRecords = true
+    },
+    getMonth() {
+      return Number(this.date.split('-')[1])
+    },
+    getYear() {
+      return Number(this.date.split('-')[0])
     },
   },
   watch: {
@@ -159,21 +168,72 @@ export default {
     <v-container v-if="showBillingRecords">
       <v-row v-for="facility in facilities" :key="facility.id + keyModifier">
         <v-col>
-          <IFXBillingRecordListDecimal
-            :facility="facility"
-            :date="date"
-            :organization="organization"
-            :allowInvoiceGeneration="false"
-            :allowApprovals="false"
-            :allowDownloads="allowDownloads"
-            :useDefaultMailButton="useDefaultMailButton"
-            :allowChangeExpenseCode="allowChangeExpenseCode"
-            :allowDeleteBillingRecords="allowDeleteBillingRecords"
-            :showDates="showDates"
-            :showStartDate="showStartDate"
-            :showTotals="showTotals"
-            :totalUnits="totalUnits"
-          />
+          <v-tabs v-model="currentTab">
+            <v-tab>Billing Records</v-tab>
+            <v-tab>Summary by Account</v-tab>
+            <v-tab>Summary by User</v-tab>
+            <v-tab>Summary by Product Rate</v-tab>
+            <v-tabs-items v-model="currentTab">
+              <v-tab-item>
+                <IFXBillingRecordListDecimal
+                  :facility="facility"
+                  :date="date"
+                  :organization="organization"
+                  :allowInvoiceGeneration="false"
+                  :allowApprovals="false"
+                  :allowDownloads="allowDownloads"
+                  :useDefaultMailButton="useDefaultMailButton"
+                  :allowChangeExpenseCode="allowChangeExpenseCode"
+                  :allowDeleteBillingRecords="allowDeleteBillingRecords"
+                  :showDates="showDates"
+                  :showStartDate="showStartDate"
+                  :showTotals="showTotals"
+                  :totalUnits="totalUnits"
+                />
+              </v-tab-item>
+              <v-tab-item>
+                <IFXGenericBillingSummaryList
+                  :facility="facility"
+                  :month="getMonth()"
+                  :year="getYear()"
+                  itemType="genericBillingSummary"
+                  apiString="accountBillingSummary"
+                  :headers="[
+                    { text: 'Account Name', value: 'name', sortable: true },
+                    { text: 'Expense Code / PO', value: 'code', sortable: true },
+                    { text: 'Charges', value: 'totalDecimalCharge', sortable: true, namedSlot: true, align: 'end' },
+                  ]"
+                />
+              </v-tab-item>
+              <v-tab-item>
+                <IFXGenericBillingSummaryList
+                  :facility="facility"
+                  :month="getMonth()"
+                  :year="getYear()"
+                  itemType="genericBillingSummary"
+                  apiString="userBillingSummary"
+                  :headers="[
+                    { text: 'User', value: 'productUserFullName', sortable: true },
+                    { text: 'Charges', value: 'totalDecimalCharge', sortable: true, namedSlot: true, align: 'end' },
+                  ]"
+                />
+              </v-tab-item>
+              <v-tab-item>
+                <IFXGenericBillingSummaryList
+                  :facility="facility"
+                  :month="getMonth()"
+                  :year="getYear()"
+                  itemType="genericBillingSummary"
+                  apiString="productRateBillingSummary"
+                  :headers="[
+                    { text: 'Product', value: 'productName', sortable: true },
+                    { text: 'Rate', value: 'rateName', sortable: true },
+                    { text: 'Charges', value: 'totalDecimalCharge', sortable: true, namedSlot: true, align: 'end' },
+                  ]"
+                />
+              </v-tab-item>
+            </v-tabs-items>
+          </v-tabs>
         </v-col>
       </v-row>
     </v-container>

--- a/src/components/billingRecord/IFXBillingRecords.vue
+++ b/src/components/billingRecord/IFXBillingRecords.vue
@@ -100,8 +100,8 @@ export default {
     },
     async getFacilities() {
       this.facilities = await this.$api.facility.getList({ application_username: this.$api.vars.appName })
-      this.facilities.forEach((facility) => {
-        this.currentTabs.push(facility.id)
+      this.facilities.forEach(() => {
+        this.currentTabs.push(0)
       })
     },
     resetShowBillingRecords() {
@@ -169,14 +169,14 @@ export default {
       </v-container>
     </v-card-title>
     <v-container v-if="showBillingRecords">
-      <v-row v-for="facility in facilities" :key="facility.id + keyModifier">
+      <v-row v-for="(facility, i) in facilities" :key="facility.id + keyModifier">
         <v-col>
-          <v-tabs v-model="currentTabs[facility.id]">
+          <v-tabs v-model="currentTabs[i]">
             <v-tab>Billing Records</v-tab>
             <v-tab>Summary by Account</v-tab>
             <v-tab>Summary by User</v-tab>
             <v-tab>Summary by Product Rate</v-tab>
-            <v-tabs-items v-model="currentTabs[facility.id]">
+            <v-tabs-items v-model="currentTabs[i]">
               <v-tab-item>
                 <IFXBillingRecordListDecimal
                   :facility="facility"

--- a/src/components/billingRecord/IFXBillingRecords.vue
+++ b/src/components/billingRecord/IFXBillingRecords.vue
@@ -64,7 +64,7 @@ export default {
       itemKey: 'key',
       showBillingRecords: false,
       keyModifier: 1,
-      currentTab: 0,
+      currentTabs: [],
       actions: [
         {
           key: 'approve',
@@ -100,6 +100,9 @@ export default {
     },
     async getFacilities() {
       this.facilities = await this.$api.facility.getList({ application_username: this.$api.vars.appName })
+      this.facilities.forEach((facility) => {
+        this.currentTabs.push(facility.id)
+      })
     },
     resetShowBillingRecords() {
       this.showBillingRecords = false
@@ -168,12 +171,12 @@ export default {
     <v-container v-if="showBillingRecords">
       <v-row v-for="facility in facilities" :key="facility.id + keyModifier">
         <v-col>
-          <v-tabs v-model="currentTab">
+          <v-tabs v-model="currentTabs[facility.id]">
             <v-tab>Billing Records</v-tab>
             <v-tab>Summary by Account</v-tab>
             <v-tab>Summary by User</v-tab>
             <v-tab>Summary by Product Rate</v-tab>
-            <v-tabs-items v-model="currentTab">
+            <v-tabs-items v-model="currentTabs[facility.id]">
               <v-tab-item>
                 <IFXBillingRecordListDecimal
                   :facility="facility"

--- a/src/components/billingSummary/IFXAccountBillingSummary.js
+++ b/src/components/billingSummary/IFXAccountBillingSummary.js
@@ -1,0 +1,64 @@
+import IFXItemBase from '@/components/item/IFXItemBase'
+
+export default class AccountBillingSummary extends IFXItemBase {
+  constructor(data = {}) {
+    super(data)
+    this.data = data
+  }
+
+  get name() {
+    return this.data.name
+  }
+
+  set name(name) {
+    this.data.name = name
+  }
+
+  get code() {
+    return this.data.code
+  }
+
+  set code(code) {
+    this.data.code = code
+  }
+
+  get organization() {
+    return this.data.organization
+  }
+
+  set organization(organization) {
+    this.data.organization = organization
+  }
+
+  get accountType() {
+    return this.data.account_type
+  }
+
+  set accountType(accountType) {
+    this.data.account_type = accountType
+  }
+
+  get totalDecimalCharge() {
+    return this.data.total_decimal_charge
+  }
+
+  set totalDecimalCharge(totalDecimalCharge) {
+    this.data.total_decimal_charge = totalDecimalCharge
+  }
+
+  get month() {
+    return this.data.month
+  }
+
+  set month(month) {
+    this.data.month = month
+  }
+
+  get year() {
+    return this.data.year
+  }
+
+  set year(year) {
+    this.data.year = year
+  }
+}

--- a/src/components/billingSummary/IFXGenericBillingSummaryList.vue
+++ b/src/components/billingSummary/IFXGenericBillingSummaryList.vue
@@ -119,6 +119,7 @@ export default {
         :selected.sync="selected"
         :itemType="itemType"
         :showSelect="false"
+        :defaultItemsPerPage="-1"
       >
         <template #totalDecimalCharge="{ item }">
           <span v-if="item.totalDecimalCharge">

--- a/src/components/billingSummary/IFXGenericBillingSummaryList.vue
+++ b/src/components/billingSummary/IFXGenericBillingSummaryList.vue
@@ -1,0 +1,89 @@
+<script>
+import IFXItemDataTable from '@/components/item/IFXItemDataTable'
+import IFXItemListMixin from '@/components/item/IFXItemListMixin'
+
+export default {
+  name: 'GenericBillingSummaryList',
+  mixins: [IFXItemListMixin],
+  components: {
+    IFXItemDataTable,
+  },
+  props: {
+    facility: {
+      required: true,
+      type: Object,
+    },
+    apiString: {
+      required: true,
+      type: String,
+    },
+    itemType: {
+      required: true,
+      type: String,
+    },
+    headers: {
+      required: true,
+      type: Array,
+    },
+    month: {
+      required: false,
+      default: new Date().getMonth(),
+      type: Number,
+    },
+    year: {
+      required: false,
+      default: new Date().getFullYear(),
+      type: Number,
+    },
+    extraParams: {
+      required: false,
+      default: () => {},
+      type: Object,
+    },
+  },
+  data() {
+    return {
+      fetchingData: false,
+    }
+  },
+  mounted() {},
+  methods: {
+    async getSetItems() {
+      this.fetchingData = true
+
+      const params = {
+        month: this.month,
+        year: this.year,
+        invoice_prefix: this.facility.invoicePrefix,
+        ...this.extraParams,
+      }
+      this.items = await this.$api[this.apiString].getList(params)
+      this.fetchingData = false
+    },
+  },
+  computed: {
+    filteredHeaders() {
+      return this.headers.filter((h) => !h.hide || !this.$vuetify.breakpoint[h.hide])
+    },
+  },
+}
+</script>
+
+<template>
+  <v-container v-if="!isLoading">
+    <IFXItemDataTable
+      :items="items"
+      :headers="filteredHeaders"
+      :selected.sync="selected"
+      :itemType="itemType"
+      :showSelect="false"
+    >
+      <template #totalDecimalCharge="{ item }">
+        <span v-if="item.totalDecimalCharge">
+          {{ item.totalDecimalCharge | dollars }}
+        </span>
+        <span v-else class="grey--text text--darken-1">No Charges</span>
+      </template>
+    </IFXItemDataTable>
+  </v-container>
+</template>

--- a/src/components/billingSummary/IFXGenericBillingSummaryList.vue
+++ b/src/components/billingSummary/IFXGenericBillingSummaryList.vue
@@ -44,6 +44,8 @@ export default {
   data() {
     return {
       fetchingData: false,
+      message: '',
+      messageType: 'info',
     }
   },
   mounted() {},
@@ -57,8 +59,31 @@ export default {
         invoice_prefix: this.facility.invoicePrefix,
         ...this.extraParams,
       }
-      this.items = await this.$api[this.apiString].getList(params)
+      try {
+        this.items = await this.$api[this.apiString].getList(params)
+      } catch (error) {
+        const errorMessage = this.getErrorMessage(error)
+        this.messageType = 'error'
+        this.message = `Error loading ${this.facility.name} billing records: ${errorMessage}`
+      }
       this.fetchingData = false
+    },
+    getErrorMessage(error) {
+      // Regular showMessage is not getting the response data properly
+      let message = 'Unknown error'
+      if (error) {
+        if (
+          error.hasOwnProperty('response')
+          && error.response
+          && error.response.hasOwnProperty('data')
+          && error.response.data
+        ) {
+          message = Object.values(error.response.data).join('\n')
+        } else {
+          message = error
+        }
+      }
+      return message
     },
   },
   computed: {
@@ -71,6 +96,13 @@ export default {
 
 <template>
   <v-container v-if="!isLoading">
+    <v-row dense class="d-flex justify-space-around" v-if="message">
+      <v-col cols="12" class="d-flex flex-grow-1">
+        <v-alert dismissible :type="messageType" border="left" elevation="2" colored-border>
+          <span v-html="message"></span>
+        </v-alert>
+      </v-col>
+    </v-row>
     <IFXItemDataTable
       :items="items"
       :headers="filteredHeaders"

--- a/src/components/billingSummary/IFXGenericBillingSummaryList.vue
+++ b/src/components/billingSummary/IFXGenericBillingSummaryList.vue
@@ -95,27 +95,44 @@ export default {
 </script>
 
 <template>
-  <v-container v-if="!isLoading">
-    <v-row dense class="d-flex justify-space-around" v-if="message">
-      <v-col cols="12" class="d-flex flex-grow-1">
-        <v-alert dismissible :type="messageType" border="left" elevation="2" colored-border>
-          <span v-html="message"></span>
-        </v-alert>
-      </v-col>
-    </v-row>
-    <IFXItemDataTable
-      :items="items"
-      :headers="filteredHeaders"
-      :selected.sync="selected"
-      :itemType="itemType"
-      :showSelect="false"
-    >
-      <template #totalDecimalCharge="{ item }">
-        <span v-if="item.totalDecimalCharge">
-          {{ item.totalDecimalCharge | dollars }}
-        </span>
-        <span v-else class="grey--text text--darken-1">No Charges</span>
-      </template>
-    </IFXItemDataTable>
+  <v-container class="fit-content" v-if="!isLoading">
+    <v-card>
+      <v-card-title>
+        <v-row class="d-flex justify-space-between w-full">
+          <v-col cols="4">
+            <div class="text-no-wrap">
+              {{ facility.name }}
+            </div>
+          </v-col>
+        </v-row>
+      </v-card-title>
+      <v-row dense class="d-flex justify-space-around" v-if="message">
+        <v-col cols="12" class="d-flex flex-grow-1">
+          <v-alert dismissible :type="messageType" border="left" elevation="2" colored-border>
+            <span v-html="message"></span>
+          </v-alert>
+        </v-col>
+      </v-row>
+      <IFXItemDataTable
+        :items="items"
+        :headers="filteredHeaders"
+        :selected.sync="selected"
+        :itemType="itemType"
+        :showSelect="false"
+      >
+        <template #totalDecimalCharge="{ item }">
+          <span v-if="item.totalDecimalCharge">
+            {{ item.totalDecimalCharge | dollars }}
+          </span>
+          <span v-else class="grey--text text--darken-1">No Charges</span>
+        </template>
+      </IFXItemDataTable>
+    </v-card>
   </v-container>
 </template>
+<style lang="scss" scoped>
+.fit-content {
+  width: fit-content;
+  margin-left: 0;
+}
+</style>

--- a/src/components/billingSummary/IFXLabBillingSummaryList.vue
+++ b/src/components/billingSummary/IFXLabBillingSummaryList.vue
@@ -59,7 +59,7 @@ export default {
         monthRange += 12 * (this.endYear - this.startYear)
       }
 
-      for (let i = 0; i < monthRange; i++) {
+      for (let i = 0; i <= monthRange; i++) {
         // Add a header for this month
         const thisMonth = (this.startMonth + i) % 12
         // the keys that come back from Django are padded to 2 digits for month.
@@ -131,6 +131,9 @@ export default {
   <v-container>
     <IFXPageHeader>
       <template #title>Lab Billing Summary</template>
+      <template #subtitle>
+        <span>{{ facility.name }}</span>
+      </template>
       <template #actions>
         <span class="d-flex flex-row flex-nowrap">
           <IFXSearchField :search.sync="search" />
@@ -211,6 +214,7 @@ export default {
       :showSelect="false"
       itemType="labBillingSummary"
       :loading="fetchingData"
+      :defaultItemsPerPage="-1"
     >
       <template v-for="header in headers" #[header.value]="{ item }">
         <span :key="header.text">

--- a/src/components/billingSummary/IFXLabBillingSummaryList.vue
+++ b/src/components/billingSummary/IFXLabBillingSummaryList.vue
@@ -128,7 +128,7 @@ export default {
 </script>
 
 <template>
-  <v-container v-if="!isLoading">
+  <v-container>
     <IFXPageHeader>
       <template #title>Lab Billing Summary</template>
       <template #actions>

--- a/src/components/billingSummary/IFXProductRateBillingSummary.js
+++ b/src/components/billingSummary/IFXProductRateBillingSummary.js
@@ -1,0 +1,40 @@
+import IFXItemBase from '@/components/item/IFXItemBase'
+
+export default class ProductRateBillingSummary extends IFXItemBase {
+  constructor(data = {}) {
+    super(data)
+    this.data = data
+  }
+
+  get productName() {
+    return this.data.product_name
+  }
+
+  set productName(productName) {
+    this.data.product_name = productName
+  }
+
+  get rateName() {
+    return this.data.rate_name
+  }
+
+  set rateName(rateName) {
+    this.data.rate_name = rateName
+  }
+
+  get totalDecimalQuantity() {
+    return this.data.total_decimal_quantity
+  }
+
+  set totalDecimalQuantity(totalDecimalQuantity) {
+    this.data.total_decimal_quantity = totalDecimalQuantity
+  }
+
+  get totalDecimalCharge() {
+    return this.data.total_decimal_charge
+  }
+
+  set totalDecimalCharge(totalDecimalCharge) {
+    this.data.total_decimal_charge = totalDecimalCharge
+  }
+}

--- a/src/components/billingSummary/IFXUserBillingSummary.js
+++ b/src/components/billingSummary/IFXUserBillingSummary.js
@@ -1,0 +1,24 @@
+import IFXItemBase from '@/components/item/IFXItemBase'
+
+export default class UserBillingSummary extends IFXItemBase {
+  constructor(data = {}) {
+    super(data)
+    this.data = data
+  }
+
+  get productUserFullName() {
+    return this.data.product_user_full_name
+  }
+
+  set productUserFullName(productUserFullName) {
+    this.data.product_user_full_name = productUserFullName
+  }
+
+  get totalDecimalCharge() {
+    return this.data.total_decimal_charge
+  }
+
+  set totalDecimalCharge(totalDecimalCharge) {
+    this.data.total_decimal_charge = totalDecimalCharge
+  }
+}

--- a/src/components/item/IFXItemDataTable.vue
+++ b/src/components/item/IFXItemDataTable.vue
@@ -60,6 +60,11 @@ export default {
       required: false,
       default: true,
     },
+    defaultItemsPerPage: {
+      type: Number,
+      required: false,
+      default: 10,
+    },
   },
   data: () => ({
     currentPage: 1,

--- a/src/entrypoint.js
+++ b/src/entrypoint.js
@@ -120,6 +120,7 @@ import IFXBillableMixin from '@/components/billingRecord/IFXBillableMixin'
 
 // Billing Summaries
 import IFXLabBillingSummaryList from '@/components/billingSummary/IFXLabBillingSummaryList'
+import IFXGenericBillingSummaryList from '@/components/billingSummary/IFXGenericBillingSummaryList'
 
 // Reports
 import IFXReportRunList from '@/components/report/IFXReportRunList'
@@ -269,6 +270,7 @@ export {
   IFXRequestCommentList,
   IFXRequestList,
   IFXLabBillingSummaryList,
+  IFXGenericBillingSummaryList,
 }
 
 // Registered globally

--- a/src/mixins/IFXMixin.js
+++ b/src/mixins/IFXMixin.js
@@ -269,10 +269,6 @@ export default {
     rt() {
       return this.$route
     },
-    // Default items displayed on list components
-    defaultItemsPerPage() {
-      return 10
-    },
     // Default page options for list components
     defaultItemsPerPageOptions() {
       return [10, 20, { text: 'All', value: -1 }]


### PR DESCRIPTION
This pull request adds new billing summary functionalities to the `IFXAPIService` and updates the `IFXBillingRecords` component to include tabs for different billing summaries. It also introduces new components and classes to handle these billing summaries.  Also adds a defaultRowsPerPage prop to the IFXItemDataTable so that the summaries can be forced into the "all" rows mode.

### New Billing Summary Functionalities:

* Added imports for `AccountBillingSummary`, `UserBillingSummary`, and `ProductRateBillingSummary` in `src/api/IFXAPI.js`.
* Implemented new getter methods in `IFXAPIService` for fetching billing summaries by account, user, and product rate.

### Updates to `IFXBillingRecords` Component:

* Added `IFXGenericBillingSummaryList` component to `IFXBillingRecords.vue`.
* Introduced a new `currentTab` state and updated the component to include tabs for different billing summaries. [[1]](diffhunk://#diff-d874cbee1ab8c036b34585e61f4cf7361deaa989c2eaef13788e47225b7874f1R67) [[2]](diffhunk://#diff-d874cbee1ab8c036b34585e61f4cf7361deaa989c2eaef13788e47225b7874f1R171-R177) [[3]](diffhunk://#diff-d874cbee1ab8c036b34585e61f4cf7361deaa989c2eaef13788e47225b7874f1R193-R236)

### New Components and Classes:

* Created `IFXGenericBillingSummaryList.vue` for displaying generic billing summaries.
* Added classes for `AccountBillingSummary`, `UserBillingSummary`, and `ProductRateBillingSummary` to handle billing summary data. [[1]](diffhunk://#diff-3a81504fa7ae93179a4b27075e550bd1ce2b0f1650fbf9af01725249ba74a117R1-R64) [[2]](diffhunk://#diff-7828be78cfdddc311d99e66b74e0598840c9dcb5f2b07a4738ce86ec418d04beR1-R24) [[3]](diffhunk://#diff-0048da7df73cab7276ffa4a2e221d4fcc7c0902eef7bd18c0f18095ea27b1ec2R1-R40)

### Other Changes:

* Updated `src/entrypoint.js` to include the new `IFXGenericBillingSummaryList` component. [[1]](diffhunk://#diff-0bebac3c41a0ab3188435145822262a6abc69c886d1d8f03bba1d7fa457406dfR123) [[2]](diffhunk://#diff-0bebac3c41a0ab3188435145822262a6abc69c886d1d8f03bba1d7fa457406dfR273)