### PR TITLE
Billing contacts

### DIFF
--- a/src/api/IFXAPI.js
+++ b/src/api/IFXAPI.js
@@ -1069,4 +1069,16 @@ export default class IFXAPIService {
     const url = this.urls.GET_CHARGE_HISTORY
     return this.axios.get(url, { params })
   }
+
+  getBillingContacts(orgSlugs, invoicePrefix) {
+    const data = {
+      org_slugs: orgSlugs,
+      invoice_prefix: invoicePrefix,
+    }
+    const headers = {
+      'Content-Type': 'application/json'
+    }
+    const url = this.urls.GET_BILLING_CONTACTS
+    return this.axios.post(url, data, { headers: headers })
+  }
 }

--- a/src/components/billingRecord/IFXBillingRecordListDecimal.vue
+++ b/src/components/billingRecord/IFXBillingRecordListDecimal.vue
@@ -647,7 +647,6 @@ export default {
       return item.currentState !== 'FINAL'
     },
     goToComposeMessage(field) {
-      console.log('facility is ', this.facility.invoicePrefix)
       this.recipientField = field
       const orgs = this.selected.length ? this.selected : this.filteredItems
       const orgSlugs = orgs.map((item) => item.account.organization)

--- a/src/components/billingRecord/IFXBillingRecordListDecimal.vue
+++ b/src/components/billingRecord/IFXBillingRecordListDecimal.vue
@@ -647,6 +647,7 @@ export default {
       return item.currentState !== 'FINAL'
     },
     goToComposeMessage(field) {
+      console.log('facility is ', this.facility.invoicePrefix)
       this.recipientField = field
       const orgs = this.selected.length ? this.selected : this.filteredItems
       const orgSlugs = orgs.map((item) => item.account.organization)
@@ -657,6 +658,7 @@ export default {
           message: null,
           subject: null,
           recipientField: this.recipientField,
+          invoicePrefix: this.facility.invoicePrefix,
         },
       })
     },

--- a/src/components/mailing/IFXMailingCompose.vue
+++ b/src/components/mailing/IFXMailingCompose.vue
@@ -168,8 +168,6 @@ export default {
           this.$api.getBillingContacts(this.labManagerOrgSlugs, this.invoicePrefix)
             .then((res) => {
               const result2 = res.data
-              console.log('result2', result2)
-              console.log('res', res)
               // If a contact for one of the orgs cannot be found, raise an error
               const orgContactNotFound = []
               me.labManagerOrgSlugs.forEach((slug) => {

--- a/src/components/mailing/IFXMailingCompose.vue
+++ b/src/components/mailing/IFXMailingCompose.vue
@@ -107,6 +107,10 @@ export default {
       return result
     },
     sendMailing() {
+      if (!this.content) {
+        this.showMessage('Please enter a message before sending.')
+        return
+      }
       const toMailStr = (contactable) => {
         if (contactable.name) {
           return `${contactable.name} <${contactable.detail}>`

--- a/src/components/mailing/IFXMailingCompose.vue
+++ b/src/components/mailing/IFXMailingCompose.vue
@@ -55,6 +55,11 @@ export default {
       required: false,
       default: null,
     },
+    invoicePrefix: {
+      type: String,
+      required: false,
+      default: null,
+    },
     recipients: {
       type: String,
       required: false,
@@ -160,15 +165,17 @@ export default {
         this.contactables = result
         // If we're doing the lab manager notification thing
         if (this.labManagerOrgSlugs) {
-          this.$api.contactables
-            .getList({ role: 'Lab Manager', org_slugs: this.labManagerOrgSlugs })
-            .then((result2) => {
+          this.$api.getBillingContacts(this.labManagerOrgSlugs, this.invoicePrefix)
+            .then((res) => {
+              const result2 = res.data
+              console.log('result2', result2)
+              console.log('res', res)
               // If a contact for one of the orgs cannot be found, raise an error
               const orgContactNotFound = []
               me.labManagerOrgSlugs.forEach((slug) => {
                 const name = this.$api.organization.parseSlug(slug).name
                 // Check if org name is in the contactable label
-                if (!result2.some((contactable) => contactable.label.indexOf(name) !== -1)) {
+                if (!result2.some((contactable) => contactable?.label?.indexOf(name) !== -1)) {
                   orgContactNotFound.push(name)
                 }
               })
@@ -196,6 +203,9 @@ export default {
                 const message = `Unable to find lab manager contact for ${names}`
                 me.showMessage(message)
               }
+            })
+            .catch((error) => {
+              this.showMessage(error)
             })
         } else {
           this.isLoading = false


### PR DESCRIPTION
When lab org slugs are passed to Mailing Compose, use the special purpose getBillingContacts API call instead of generic contactables so that billing record review roles are handled identically to the BillingRecordEmailGenerator
invoicePrefix is required since HeRS and CBSN both have multiple facilities
Also, make sure email message content is not null