### PR TITLE
More NICE

### DIFF
--- a/src/api/IFXAPI.js
+++ b/src/api/IFXAPI.js
@@ -509,7 +509,7 @@ export default class IFXAPIService {
     api.getNames = async (selector = null) => {
       const url = this.urls.ORGANIZATION_NAMES
       const orgNames = await this.axios
-        .get(url)
+        .get(url, { params: { org_trees: 'Harvard' } })
         .then((res) => res.data)
         .then((objs) => {
           if (selector) {

--- a/src/components/request/IFXDisplayLabInfo.vue
+++ b/src/components/request/IFXDisplayLabInfo.vue
@@ -44,12 +44,72 @@ export default {
           </v-layout>
           <v-layout column>
             <v-flex>
+              <v-layout row align-center>
+                <v-flex xs4>
+                  Selected Organization
+                </v-flex>
+                <v-flex>
+                  <v-autocomplete v-if="organizations"
+                    v-model.trim="data.lab_info.organization"
+                    :items="organizations"
+                    item-text="name"
+                    item-value="slug"
+                    @change="updateData()"
+                  ></v-autocomplete>
+                </v-flex>
+              </v-layout>
+            </v-flex>
+          </v-layout>
+          <v-layout column>
+            <v-flex>
               <v-layout row>
                 <v-flex xs4>
                   PI / Manager
                 </v-flex>
                 <v-flex>
                   {{ data.lab_info.pi_name }}, {{ data.lab_info.pi_email }}
+                </v-flex>
+              </v-layout>
+            </v-flex>
+          </v-layout>
+          <v-layout column>
+            <v-flex>
+              <v-layout row>
+                <v-flex xs4>
+                  &nbsp;
+                </v-flex>
+                <v-flex>
+                  {{ data.lab_info.pi_street1 }}
+                </v-flex>
+              </v-layout>
+            </v-flex>
+            <v-flex>
+              <v-layout row>
+                <v-flex xs4>
+                  &nbsp;
+                </v-flex>
+                <v-flex>
+                  {{ data.lab_info.pi_city }}, {{ data.lab_info.pi_state }} {{ data.lab_info.pi_postal_code }}
+                </v-flex>
+              </v-layout>
+            </v-flex>
+            <v-flex v-if="data.lab_info.pi_contact_country != 'United States'">
+              <v-layout row>
+                <v-flex xs4>
+                  &nbsp;
+                </v-flex>
+                <v-flex>
+                  {{ data.lab_info.pi_contact_country }}
+                </v-flex>
+              </v-layout>
+            </v-flex>
+            <v-flex>
+              <v-layout row>
+                <v-flex xs4>
+                  &nbsp;
+                </v-flex>
+                <v-flex>
+                  {{ data.lab_info.pi_phone }}
                 </v-flex>
               </v-layout>
             </v-flex>
@@ -69,18 +129,42 @@ export default {
           </v-layout>
           <v-layout column>
             <v-flex>
-              <v-layout row align-center>
+              <v-layout row>
                 <v-flex xs4>
-                  Selected Organization
+                  &nbsp;
                 </v-flex>
                 <v-flex>
-                  <v-autocomplete v-if="organizations"
-                    v-model.trim="data.lab_info.organization"
-                    :items="organizations"
-                    item-text="name"
-                    item-value="slug"
-                    @change="updateData()"
-                  ></v-autocomplete>
+                  {{ data.lab_info.billing_contact_street1 }}
+                </v-flex>
+              </v-layout>
+            </v-flex>
+            <v-flex>
+              <v-layout row>
+                <v-flex xs4>
+                  &nbsp;
+                </v-flex>
+                <v-flex>
+                  {{ data.lab_info.billing_contact_city }}, {{ data.lab_info.billing_contact_state }} {{ data.lab_info.billing_contact_postal_code }}
+                </v-flex>
+              </v-layout>
+            </v-flex>
+            <v-flex v-if="data.lab_info.billing_contact_country != 'United States'">
+              <v-layout row>
+                <v-flex xs4>
+                  &nbsp;
+                </v-flex>
+                <v-flex>
+                  {{ data.lab_info.billing_contact_country }}
+                </v-flex>
+              </v-layout>
+            </v-flex>
+            <v-flex>
+              <v-layout row>
+                <v-flex xs4>
+                  &nbsp;
+                </v-flex>
+                <v-flex>
+                  {{ data.lab_info.billing_contact_phone }}
                 </v-flex>
               </v-layout>
             </v-flex>

--- a/src/components/request/IFXDisplayLabInfo.vue
+++ b/src/components/request/IFXDisplayLabInfo.vue
@@ -15,13 +15,29 @@ export default {
   data() {
     return {
       data: this.value,
+      piContact: {},
+      billingContact: {},
     }
   },
   methods: {
     updateData() {
+      this.piContact = {}
+      this.billingContact = {}
       this.$emit('change', this.data)
       return true // This is needed to make the v-text-field work.  Don't know why
     },
+  },
+  mounted: function () {
+    if (this.data?.lab_info?.organization) {
+      const piOrgContact = this.data.lab_info.organization.contacts.find(orgContact => orgContact.role === 'PI')
+      if (piOrgContact) {
+        this.piContact = piOrgContact.contact
+      }
+      const billingOrgContact = this.data.lab_info.organization.contacts.find(orgContact => orgContact.role === 'Billing')
+      if (billingOrgContact) {
+        this.billingContact = billingOrgContact.contact
+      }
+    }
   },
 }
 </script>
@@ -60,7 +76,7 @@ export default {
               </v-layout>
             </v-flex>
           </v-layout>
-          <v-layout column>
+          <v-layout v-if="!piContact" column>
             <v-flex>
               <v-layout row>
                 <v-flex xs4>
@@ -71,8 +87,6 @@ export default {
                 </v-flex>
               </v-layout>
             </v-flex>
-          </v-layout>
-          <v-layout column>
             <v-flex>
               <v-layout row>
                 <v-flex xs4>
@@ -114,7 +128,30 @@ export default {
               </v-layout>
             </v-flex>
           </v-layout>
-          <v-layout column>
+          <v-layout v-else column>
+            <v-flex>
+              <v-layout row>
+                <v-flex xs4>
+                  PI / Manager
+                </v-flex>
+                <v-flex>
+                  {{ piContact.name }}, {{ piContact.detail }}
+                </v-flex>
+              </v-layout>
+            </v-flex>
+            <v-flex>
+              <v-layout row>
+                <v-flex xs4>
+                  &nbsp;
+                </v-flex>
+                <v-flex class="address">
+                  {{ piContact.address}}
+                </v-flex>
+              </v-layout>
+            </v-flex>
+
+          </v-layout>
+          <v-layout v-if="!billingContact" column>
             <v-flex>
               <v-layout row>
                 <v-flex xs4>
@@ -126,8 +163,6 @@ export default {
                 </v-flex>
               </v-layout>
             </v-flex>
-          </v-layout>
-          <v-layout column>
             <v-flex>
               <v-layout row>
                 <v-flex xs4>
@@ -169,9 +204,35 @@ export default {
               </v-layout>
             </v-flex>
           </v-layout>
+          <v-layout v-else column>
+            <v-flex>
+              <v-layout row>
+                <v-flex xs4>
+                  Billing Contact
+                </v-flex>
+                <v-flex>
+                  {{ billingContact.name }}, {{ billingContact.detail }}
+                </v-flex>
+              </v-layout>
+            </v-flex>
+            <v-flex>
+              <v-layout row>
+                <v-flex xs4>
+                  &nbsp;
+                </v-flex>
+                <v-flex class="address">
+                  {{ billingContact.address }}
+                </v-flex>
+              </v-layout>
+            </v-flex>
+          </v-layout>
         </v-flex>
       </v-layout>
     </v-flex>
   </v-layout>
 </template>
-<style scoped></style>
+<style scoped>
+  .address {
+    white-space: pre-line;
+  }
+</style>

--- a/src/components/request/IFXDisplayProject.vue
+++ b/src/components/request/IFXDisplayProject.vue
@@ -33,6 +33,30 @@ export default {
               </v-layout>
             </v-flex>
           </v-layout>
+          <v-layout column>
+            <v-flex>
+              <v-layout row>
+                <v-flex xs4>
+                  Estimated Start Date
+                </v-flex>
+                <v-flex>
+                  {{ data.estimated_start_date }}
+                </v-flex>
+              </v-layout>
+            </v-flex>
+          </v-layout>
+          <v-layout column>
+            <v-flex>
+              <v-layout row>
+                <v-flex xs4>
+                  Estimated duration
+                </v-flex>
+                <v-flex>
+                  {{ data.estimated_duration }}
+                </v-flex>
+              </v-layout>
+            </v-flex>
+          </v-layout>
         </v-flex>
       </v-layout>
     </v-flex>


### PR DESCRIPTION
Show PI and Billing Contact information on the DisplayLabInfo component
Make sure that getNames in the API only returns Harvard org tree.  No reason for anything else.
Show estimated start date and estimated duration for project info.