### PR TITLE
Allow HTML in IFXTooltip

### DIFF
--- a/src/components/IFXTooltip.vue
+++ b/src/components/IFXTooltip.vue
@@ -13,7 +13,8 @@
         <v-icon :dark="dark" :color="iconColor">{{ icon }}</v-icon>
       </v-btn>
     </template>
-    <span>{{ tooltip }}</span>
+    <span v-if="!isHTML">{{ tooltip }}</span>
+    <span v-else v-html="tooltip"></span>
   </v-tooltip>
 </template>
 
@@ -51,6 +52,11 @@ export default {
       default: true,
     },
     disabled: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+    isHTML: {
       type: Boolean,
       required: false,
       default: false,


### PR DESCRIPTION
This pull request includes changes to the `IFXTooltip` component to support rendering HTML content within the tooltip. The most important changes include adding a new `isHTML` prop and conditionally rendering the tooltip content based on this prop. Note that is can be dangerous if arbitrary user content is rendered this way so the `prop` defaults to `false`

Enhancements to tooltip rendering:

* [`src/components/IFXTooltip.vue`](diffhunk://#diff-9b90ebd66ce803b2720b914c2a415d3b36501e13e53b0bda4fc54649f7d2ac16R59-R63): Added a new `isHTML` prop to determine whether the tooltip content should be rendered as plain text or HTML.
* [`src/components/IFXTooltip.vue`](diffhunk://#diff-9b90ebd66ce803b2720b914c2a415d3b36501e13e53b0bda4fc54649f7d2ac16L16-R17): Updated the template to conditionally render the tooltip content using `v-if` and `v-html` based on the `isHTML` prop.
* 