### PR TITLE
Fix `getPeople` call in `IFXAddUsers`

### DIFF
--- a/src/components/organization/IFXAddUsers.vue
+++ b/src/components/organization/IFXAddUsers.vue
@@ -38,7 +38,7 @@ export default {
     getPeople: debounce(function () {
       this.isLoading = true
       this.$api[this.itemType]
-        .getList(this.search)
+        .getList({ search: this.search })
         .then((response) => {
           this.people = response
         })


### PR DESCRIPTION
This PR fixes the `getPeople call ` in `IFXAddUsers`. We now pass in an object rather than a string to `getList` as it  calls `axios.get` which expects an object as params.