### PR TITLE
Add api-layer cache to `organizations` API calls

### DIFF
--- a/src/api/IFXAPI.js
+++ b/src/api/IFXAPI.js
@@ -35,6 +35,7 @@ function isJSONString(str) {
   return true
 }
 
+const CACHE_TIMER = 1000 * 60 * 60 * 4 // 4 hours
 export default class IFXAPIService {
   constructor(store) {
     this._store = store
@@ -42,7 +43,6 @@ export default class IFXAPIService {
     this._authUser = null
     // We want to auto-clear the cache every 4 hours
     let cacheTimer = this.storage.getItem('cacheTimer', 'session')
-    console.log('Current cache timer', cacheTimer)
     if (cacheTimer) {
       try {
         // There is a left over cache timer
@@ -51,13 +51,9 @@ export default class IFXAPIService {
         console.error('Error clearing cache timer', e)
       }
     }
-    console.log('Setting cache timer')
     cacheTimer = setInterval(() => {
-      console.log('Clearing cache', cacheTimer)
       this.cache.clear('') // Clear all keys
-      // this.storage.removeItem('cacheTimer', 'session')
-    }, /* 1000 * 60 * 60 * 4 */ 1000 * 30)
-    console.log('Cache timer set', cacheTimer)
+    }, CACHE_TIMER)
     this.storage.setItem('cacheTimer', cacheTimer, 'session')
   }
 
@@ -890,11 +886,7 @@ export default class IFXAPIService {
     }
     const decomposeFunc = (newProductData) => createFunc(newProductData, true)
     const api = this.genericAPI(baseUrl, null, createFunc, decomposeFunc)
-    api.objectCodeCategories = () => [
-      'Technical Services',
-      'Laboratory Consumables',
-      'Animal Per Diem Charges',
-    ]
+    api.objectCodeCategories = () => ['Technical Services', 'Laboratory Consumables', 'Animal Per Diem Charges']
     return api
   }
 

--- a/src/api/IFXAPI.js
+++ b/src/api/IFXAPI.js
@@ -513,22 +513,26 @@ export default class IFXAPIService {
     api.getValidRankByText = (text) => api.validRanks.find((r) => r.text === text)
 
     // Wrap old update/save/delete methods to clear cache
+    // Note that we nuke both the regular and the skinny organizations
     const orgUpdate = api.update
     const orgSave = api.save
     const orgDelete = api.delete
     api.update = async (organization) => {
       const result = await orgUpdate(organization)
       this.cache.clear('organization')
+      this.cache.clear('skinnyOrganization')
       return result
     }
     api.save = async (organization) => {
       const result = await orgSave(organization)
       this.cache.clear('organization')
+      this.cache.clear('skinnyOrganization')
       return result
     }
     api.delete = async (organization) => {
       const result = await orgDelete(organization)
       this.cache.clear('organization')
+      this.cache.clear('skinnyOrganization')
       return result
     }
 

--- a/src/api/IFXAPI.js
+++ b/src/api/IFXAPI.js
@@ -40,6 +40,25 @@ export default class IFXAPIService {
     this._store = store
     this._axios = axios.create()
     this._authUser = null
+    // We want to auto-clear the cache every 4 hours
+    let cacheTimer = this.storage.getItem('cacheTimer', 'session')
+    console.log('Current cache timer', cacheTimer)
+    if (cacheTimer) {
+      try {
+        // There is a left over cache timer
+        clearInterval(cacheTimer)
+      } catch (e) {
+        console.error('Error clearing cache timer', e)
+      }
+    }
+    console.log('Setting cache timer')
+    cacheTimer = setInterval(() => {
+      console.log('Clearing cache', cacheTimer)
+      this.cache.clear('') // Clear all keys
+      // this.storage.removeItem('cacheTimer', 'session')
+    }, /* 1000 * 60 * 60 * 4 */ 1000 * 30)
+    console.log('Cache timer set', cacheTimer)
+    this.storage.setItem('cacheTimer', cacheTimer, 'session')
   }
 
   get store() {
@@ -220,6 +239,15 @@ export default class IFXAPIService {
         const userData = {}
         this.authUser = new IFXAuthUser(userData)
         this.storage.removeItem('user')
+        const cacheTimer = this.storage.getItem('cacheTimer', 'session')
+        if (cacheTimer) {
+          try {
+            // Stop any cache clearing
+            clearInterval(cacheTimer)
+          } catch (e) {
+            console.error('Error clearing cache timer', e)
+          }
+        }
         this.storage.clear('session')
         return 'You have been logged out successfully.'
       },
@@ -380,13 +408,15 @@ export default class IFXAPIService {
       // Get the list of params that have been saved for this itemType
       const keys = Object.keys(window.sessionStorage)
       if (!keys) return []
-      const computedStart = `${this.vars.appKey}_${itemType}`
+      const computedStart = `${this.vars.appKey}_cache_${itemType}`
       // Since the `clear` method is going to prepend the appKey to the itemType, we need to remove it here
       return keys.filter((key) => key.startsWith(computedStart)).map((key) => key.slice(`${this.vars.appKey}_`.length))
     }
 
+    api.getKey = (itemType, params) => `cache_${itemType}_${JSON.stringify(params)}`
+
     api.add = (itemType, params, data) => {
-      const key = `${itemType}_${JSON.stringify(params)}`
+      const key = api.getKey(itemType, params)
       try {
         this.storage.setItem(key, data, 'session')
       } catch (e) {
@@ -395,7 +425,7 @@ export default class IFXAPIService {
     }
 
     api.get = (itemType, params) => {
-      const key = `${itemType}_${JSON.stringify(params)}`
+      const key = api.getKey(itemType, params)
       const data = this.storage.getItem(key, 'session')
       if (!data) return null
       return data

--- a/src/api/IFXAPI.js
+++ b/src/api/IFXAPI.js
@@ -549,7 +549,7 @@ export default class IFXAPIService {
           .get(baseUrl, { params })
           .then((res) => {
             // Cache raw data
-            this.cache.add('organization', params, organizations)
+            this.cache.add('organization', params, res.data)
             return Promise.all(res.data.map((orgData) => this.organization.create(orgData)))
           })
           .catch((err) => {

--- a/src/api/IFXAPI.js
+++ b/src/api/IFXAPI.js
@@ -380,7 +380,9 @@ export default class IFXAPIService {
       // Get the list of params that have been saved for this itemType
       const keys = Object.keys(window.sessionStorage)
       if (!keys) return []
-      return keys.filter((key) => key.startsWith(itemType))
+      const computedStart = `${this.vars.appKey}_${itemType}`
+      // Since the `clear` method is going to prepend the appKey to the itemType, we need to remove it here
+      return keys.filter((key) => key.startsWith(computedStart)).map((key) => key.slice(`${this.vars.appKey}_`.length))
     }
 
     api.add = (itemType, params, data) => {

--- a/src/api/IFXAPI.js
+++ b/src/api/IFXAPI.js
@@ -373,6 +373,40 @@ export default class IFXAPIService {
     return this.genericAPI(baseUrl, User)
   }
 
+  get cache() {
+    const api = {}
+
+    api.getParamList = (itemType) => {
+      // Get the list of params that have been saved for this itemType
+      const keys = Object.keys(window.sessionStorage)
+      if (!keys) return []
+      return keys.filter((key) => key.startsWith(itemType))
+    }
+
+    api.add = (itemType, params, data) => {
+      const key = `${itemType}_${JSON.stringify(params)}`
+      try {
+        this.storage.setItem(key, data, 'session')
+      } catch (e) {
+        console.error(e)
+      }
+    }
+
+    api.get = (itemType, params) => {
+      const key = `${itemType}_${JSON.stringify(params)}`
+      const data = this.storage.getItem(key, 'session')
+      if (!data) return null
+      return data
+    }
+
+    api.clear = (itemType) => {
+      const keys = api.getParamList(itemType)
+      keys.forEach((key) => this.storage.removeItem(key, 'session'))
+    }
+
+    return api
+  }
+
   get organization() {
     const baseUrl = this.urls.ORGANIZATIONS
     const skinnyListUrl = this.urls.SKINNY_ORGANIZATIONS
@@ -476,18 +510,49 @@ export default class IFXAPIService {
     api.getValidRankByValue = (value) => api.validRanks.find((r) => r.value === value)
     api.getValidRankByText = (text) => api.validRanks.find((r) => r.text === text)
 
+    // Wrap old update/save/delete methods to clear cache
+    const orgUpdate = api.update
+    const orgSave = api.save
+    const orgDelete = api.delete
+    api.update = async (organization) => {
+      const result = await orgUpdate(organization)
+      this.cache.clear('organization')
+      return result
+    }
+    api.save = async (organization) => {
+      const result = await orgSave(organization)
+      this.cache.clear('organization')
+      return result
+    }
+    api.delete = async (organization) => {
+      const result = await orgDelete(organization)
+      this.cache.clear('organization')
+      return result
+    }
+
     api.getList = async (params = {}) => {
       const { orgTrees } = params
       if (orgTrees) {
         params.org_tree = orgTrees.join(',')
         delete params.orgTrees
       }
-      const organizations = await this.axios
-        .get(baseUrl, { params })
-        .then((res) => Promise.all(res.data.map((orgData) => this.organization.create(orgData))))
-        .catch((err) => {
-          throw new Error(err)
-        })
+      // Check cache for this item type and params
+      let organizations = this.cache.get('organization', params)
+      if (!organizations) {
+        organizations = await this.axios
+          .get(baseUrl, { params })
+          .then((res) => {
+            // Cache raw data
+            this.cache.add('organization', params, organizations)
+            return Promise.all(res.data.map((orgData) => this.organization.create(orgData)))
+          })
+          .catch((err) => {
+            throw new Error(err)
+          })
+      } else {
+        // Convert raw data to objects
+        organizations = organizations.map((orgData) => this.organization.create(orgData))
+      }
       return organizations || []
     }
     api.getSkinnyList = async (params = {}) => {
@@ -496,12 +561,22 @@ export default class IFXAPIService {
         params.org_tree = orgTrees.join(',')
         delete params.orgTrees
       }
-      const organizations = await this.axios
-        .get(skinnyListUrl, { params })
-        .then((res) => Promise.all(res.data.map((orgData) => this.organization.create(orgData))))
-        .catch((err) => {
-          throw new Error(err)
-        })
+      let organizations = this.cache.get('skinnyOrganization', params)
+      if (!organizations) {
+        organizations = await this.axios
+          .get(skinnyListUrl, { params })
+          .then((res) => {
+            // Cache raw data
+            this.cache.add('skinnyOrganization', params, res.data)
+            return Promise.all(res.data.map((orgData) => this.organization.create(orgData)))
+          })
+          .catch((err) => {
+            throw new Error(err)
+          })
+      } else {
+        // Convert raw data to objects
+        organizations = organizations.map((orgData) => this.organization.create(orgData))
+      }
       return organizations || []
     }
     // this has been added to the object itelf
@@ -1082,7 +1157,7 @@ export default class IFXAPIService {
       invoice_prefix: invoicePrefix,
     }
     const headers = {
-      'Content-Type': 'application/json'
+      'Content-Type': 'application/json',
     }
     const url = this.urls.GET_BILLING_CONTACTS
     return this.axios.post(url, data, { headers: headers })


### PR DESCRIPTION
This pull request introduces significant improvements to the `IFXAPIService` class by adding caching mechanisms for API responses and ensuring cache invalidation when data is updated, saved, or deleted. The most important changes include the addition of a `cache` getter, wrapping existing methods to clear the cache, and modifying the `getList` and `getSkinnyList` methods to utilize the cache.

Cache is now "auto-cleared" every 4 hours.

We use **session storage** for the cache so logging out or closing the browser tab will remove the cached data.

Note that only the raw data from the networkl is cached so `organization` objects must be recreated for each API call.  Note also that changes to `organizations` by other users won't invalidate the caches since we don't know about them. But organizations don't change that frequently.

### Caching Mechanism:

* Added a `cache` getter that provides methods to add, get, and clear cached data using session storage.

### Cache Invalidation:

* Wrapped the `update`, `save`, and `delete` methods to clear the cache for `organization` and `skinnyOrganization` after these operations are performed.

### Cache Utilization:

* Modified the `getList` method to check the cache before making an API call and to cache the response data.
* Modified the `getSkinnyList` method to check the cache before making an API call and to cache the response data.

### Minor Code Style Change:

* Added a trailing comma to the `headers` object in the `getBillingContacts` method.