### PR TITLE
Fix the check on `endMonth` being 0

### DIFF
--- a/src/components/billingSummary/IFXLabBillingSummaryList.vue
+++ b/src/components/billingSummary/IFXLabBillingSummaryList.vue
@@ -38,10 +38,10 @@ export default {
     }
   },
   mounted() {
-    if (!this.startMonth) {
+    if (!this.endMonth) {
       // If we're at the start of the year, we need to go back to the previous year
       // Since getMonth() is zero-based, we're using that to go to the previous month
-      this.startMonth = 12
+      this.endMonth = 12
       this.endYear--
     }
     this.startYear = this.endYear

--- a/src/components/billingSummary/IFXLabBillingSummaryList.vue
+++ b/src/components/billingSummary/IFXLabBillingSummaryList.vue
@@ -22,7 +22,7 @@ export default {
   },
   data() {
     return {
-      DEFAULT_RANGE: 6,
+      DEFAULT_RANGE: 5,
       onlyShowSuspiciousRows: false,
       theHeaders: [{ text: 'Lab Name', value: 'organization', sortable: true }],
       startMonth: null,


### PR DESCRIPTION
We want to end on the previous month so we use `getMonth()`, which is zero-based (i.e. one less than we normally refer to months). But we need to check if we’re at month 0 (Jan) and back it off to Dec of the previous year.

This PR fixes the check for the end month being 0 to actually check the `endMonth` and do the right thing. Also, because we're ending on the previous month, set the `DEFAULT_RANGE` to 5 so we effectively go back 6 months, by default.
