### PR TITLE
Allow the creator (aka `productUser`) to cancel a reservation

### DIFF
--- a/src/components/calendar/IFXCalendarList.vue
+++ b/src/components/calendar/IFXCalendarList.vue
@@ -401,7 +401,8 @@ export default {
       return false
     },
     canCancelReservation(item) {
-      return this.$api.auth.can('cancel-reservation', this.$api.authUser) && !item.cancelled
+      const canCancel = this.$api.auth.can('cancel-reservation', this.$api.authUser) || item.productUser.id === this.currentUser.id
+      return canCancel && !item.cancelled
     },
     canApprove() {
       return this.$api.auth.can('approve-reservation', this.$api.authUser)


### PR DESCRIPTION
This pull request includes a change to the `src/components/calendar/IFXCalendarList.vue` file to improve the logic for determining if a reservation can be canceled. The most important change is the enhancement of the `canCancelReservation` method to allow cancellation if the current user is the product user, in addition to the existing authorization check.

* [`src/components/calendar/IFXCalendarList.vue`](diffhunk://#diff-678088fdfef5986b29cf6245b43cfb79e2c5a820a2f24f0bd979ce82719b8970L404-R405): Enhanced the `canCancelReservation` method to allow cancellation if the current user is the product user (`item.productUser.id === this.currentUser.id`), in addition to the existing authorization check.