### PR TITLE
More account request tweaks

### DIFF
--- a/src/components/request/IFXDisplayDemographicData.vue
+++ b/src/components/request/IFXDisplayDemographicData.vue
@@ -68,16 +68,6 @@ export default {
             </v-flex>
           </v-layout>
         </v-flex>
-        <v-flex>
-          <v-layout row>
-            <v-flex xs4>
-              Visa details
-            </v-flex>
-            <v-flex>
-              {{ data.visa_details }}
-            </v-flex>
-          </v-layout>
-        </v-flex>
       </v-layout>
     </v-flex>
   </v-layout>

--- a/src/components/request/IFXDisplayLabInfo.vue
+++ b/src/components/request/IFXDisplayLabInfo.vue
@@ -28,7 +28,7 @@ export default {
     },
   },
   mounted: function () {
-    if (this.data?.lab_info?.organization) {
+    if (this.data?.lab_info?.organization?.contacts) {
       const piOrgContact = this.data.lab_info.organization.contacts.find(orgContact => orgContact.role === 'PI')
       if (piOrgContact) {
         this.piContact = piOrgContact.contact
@@ -69,14 +69,14 @@ export default {
                     v-model.trim="data.lab_info.organization"
                     :items="organizations"
                     item-text="name"
-                    item-value="slug"
+                    return-object
                     @change="updateData()"
                   ></v-autocomplete>
                 </v-flex>
               </v-layout>
             </v-flex>
           </v-layout>
-          <v-layout v-if="!piContact" column>
+          <v-layout v-if="Object.keys(piContact).length === 0" column>
             <v-flex>
               <v-layout row>
                 <v-flex xs4>
@@ -149,9 +149,8 @@ export default {
                 </v-flex>
               </v-layout>
             </v-flex>
-
           </v-layout>
-          <v-layout v-if="!billingContact" column>
+          <v-layout v-if="Object.keys(billingContact).length === 0" column>
             <v-flex>
               <v-layout row>
                 <v-flex xs4>


### PR DESCRIPTION
Remove visa detail from demographic info display
Use proper test for empty piContact and billingContact object 
Return object for organization that is selected in account request detail display because the processor expects it