### PR TITLE
Add Primary Affiliation to `IFXUser`

### DIFF
--- a/src/components/request/IFXAccountRequestDetail.vue
+++ b/src/components/request/IFXAccountRequestDetail.vue
@@ -176,7 +176,7 @@ export default {
   },
   computed: {
     django_admin_url: function () {
-      return [this.$api.urls.DJANGO_ADMIN_ROOT, 'ifxrequest', 'request', this.request.id, 'change/'].join('/')
+      return `${this.$api.urls.DJANGO_ADMIN_ROOT}ifxrequest/request/${this.request.id}/change/`
     },
   },
   beforeRouteLeave(to, from, next) {
@@ -291,9 +291,7 @@ export default {
               </v-flex>
               <v-flex xs6 v-if="canBeApproved()">
                 <v-layout row justify-end>
-                  <v-flex grow>
-                    &nbsp;
-                  </v-flex>
+                  <v-flex grow>&nbsp;</v-flex>
                   <v-flex shrink>
                     <v-radio-group :column="false" v-model="approval" @change="updateRequestState()">
                       <v-radio label="Approve" value="approve"></v-radio>
@@ -319,10 +317,11 @@ export default {
                   <v-flex>
                     <span class="title">Request Files</span>
                   </v-flex>
-                  <v-flex v-for="accountRequestFileData in request.requestData.request_files" :key="accountRequestFileData.id">
-                    <IFXAccountRequestFile
-                      :accountRequestFileData="accountRequestFileData"
-                    />
+                  <v-flex
+                    v-for="accountRequestFileData in request.requestData.request_files"
+                    :key="accountRequestFileData.id"
+                  >
+                    <IFXAccountRequestFile :accountRequestFileData="accountRequestFileData" />
                   </v-flex>
                 </v-layout>
               </v-flex>

--- a/src/components/user/IFXUserDetail.vue
+++ b/src/components/user/IFXUserDetail.vue
@@ -468,6 +468,7 @@ export default {
               :item.sync="itemCopy"
               :errors="errors"
               :allGroupNames="allGroupNames"
+              :orgSlugs="allOrganizationSlugs"
               :valid.sync="userInfoDialogValid"
             />
             <slot name="additionalUserInfoEdit" :item="itemCopy" :errors="errors"></slot>

--- a/src/components/user/IFXUserDetail.vue
+++ b/src/components/user/IFXUserDetail.vue
@@ -152,7 +152,7 @@ export default {
   },
   computed: {
     django_admin_url() {
-      return [this.$api.urls.DJANGO_ADMIN_ROOT, 'ifxuser', 'ifxuser', this.item.id, 'change/'].join('/')
+      return `${this.$api.urls.DJANGO_ADMIN_ROOT}ifxuser/ifxuser/${this.item.id}/change/`
     },
     areAnyAccountsPresent() {
       return this.item.accounts?.length || this.item.productAccounts?.length

--- a/src/components/user/IFXUserInfoEdit.vue
+++ b/src/components/user/IFXUserInfoEdit.vue
@@ -10,6 +10,10 @@ export default {
       type: Array,
       required: true,
     },
+    orgSlugs: {
+      type: Array,
+      required: true,
+    },
     item: {
       type: Object,
       required: true,
@@ -39,6 +43,9 @@ export default {
       if (this.errors.hasOwnProperty(key)) {
         this.$delete(this.errors, key)
       }
+    },
+    trimOrgName(slug) {
+      return this.$api.organization.parseSlug(slug).name
     },
   },
   watch: {
@@ -148,6 +155,29 @@ export default {
             ></v-text-field>
           </v-col>
           <v-col sm="6">
+            <v-autocomplete
+              v-model.trim="itemLocal.primaryAffiliation"
+              :items="orgSlugs"
+              hint="The user's primary affiliation."
+              persistent-hint
+              label="Primary Affiliation"
+              :error-messages="errors.primary_affiliation"
+              @focus="clearError('primary_affiliation')"
+              :disabled="!canEdit('User.primaryAffiliation')"
+              :rules="formRules.generic"
+              required
+            >
+              <template #item="{ item }">
+                {{ trimOrgName(item) }}
+              </template>
+              <template #selection="{ item }">
+                {{ trimOrgName(item) }}
+              </template>
+            </v-autocomplete>
+          </v-col>
+        </v-row>
+        <v-row>
+          <v-col sm="6" offset="6">
             <v-switch
               :label="`${this.$api.vars.appNameFormatted} Login`"
               :disabled="!canEdit('User.isActive')"

--- a/src/mixins/IFXMixin.js
+++ b/src/mixins/IFXMixin.js
@@ -81,17 +81,11 @@ export default {
       // If today is Friday and it is 11am or later, first business day is next monday
       if (todayInt === 5 && hour >= 11) {
         // Add one week to today and get monday of that week
-        return now
-          .clone()
-          .add(1, 'week')
-          .isoWeekday(1)
+        return now.clone().add(1, 'week').isoWeekday(1)
       }
       if ([6, 7].includes(todayInt)) {
         // If today is Saturday or Sunday, first business day is next monday
-        return now
-          .clone()
-          .add(1, 'week')
-          .isoWeekday(1)
+        return now.clone().add(1, 'week').isoWeekday(1)
       }
       // If it is a weekday and it is before 11am, today is the first business day
       if (hour < 11) {
@@ -113,17 +107,11 @@ export default {
       }
       // If firstBusinessDay is Thursday, deliver next Monday
       if (firstBusinessDay.isoWeekday() === 4) {
-        return firstBusinessDay
-          .clone()
-          .add(1, 'week')
-          .isoWeekday(1)
+        return firstBusinessDay.clone().add(1, 'week').isoWeekday(1)
       }
       // If firstBusinessDay is Friday, deliver next Tuesday
       if (firstBusinessDay.isoWeekday() === 5) {
-        return firstBusinessDay
-          .clone()
-          .add(1, 'week')
-          .isoWeekday(2)
+        return firstBusinessDay.clone().add(1, 'week').isoWeekday(2)
       }
       return null
     },
@@ -315,13 +303,17 @@ export default {
          * @param {any} v
          * @returns {boolean | string}
          */
-        email: [baseRule, (v) => /^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$/.test(v) || 'E-mail must be valid'],
+        email: [baseRule, (v) => /^\w+([+.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$/.test(v) || 'E-mail must be valid'],
         /**
          * Checks if value is a valid phone # (10 digits)
          * @param {any} v
          * @returns {boolean | string}
          */
-        phone: [baseRule, (v) => /^[+]?[\s./0-9]*[(]?[0-9]{1,4}[)]?[-\s./0-9]*$/g.test(v) || 'Phone number must be, digits, hyphens or parens only'],
+        phone: [
+          baseRule,
+          (v) => /^[+]?[\s./0-9]*[(]?[0-9]{1,4}[)]?[-\s./0-9]*$/g.test(v)
+            || 'Phone number must be, digits, hyphens or parens only',
+        ],
         /**
          * Checks if value is valid currency
          * @param {any} v


### PR DESCRIPTION
This pull request includes several changes to the `IFXUserDetail.vue`, `IFXUserInfoEdit.vue`, and `IFXMixin.js` files to enhance functionality and improve code readability. The most important changes include adding organization slugs to user details, implementing a new method to trim organization names, adding a new autocomplete field for primary affiliation, and simplifying code in the mixin file.

Enhancements to user details:

* [`src/components/user/IFXUserDetail.vue`](diffhunk://#diff-f455e0eafa7fce074fc05a5cafaca51feaf4cc0ce1c0fcb02d337b0ead5e8236R471): Added `orgSlugs` property to pass organization slugs to the user info component.

Enhancements to user info editing:

* [`src/components/user/IFXUserInfoEdit.vue`](diffhunk://#diff-4835b53b8c3974fc062cd04552bb883d6a24f06d9339cc831b5f4f96f26663b2R13-R16): Added `orgSlugs` property to accept an array of organization slugs.
* [`src/components/user/IFXUserInfoEdit.vue`](diffhunk://#diff-4835b53b8c3974fc062cd04552bb883d6a24f06d9339cc831b5f4f96f26663b2R47-R49): Implemented `trimOrgName` method to parse and return the organization name from a slug.
* [`src/components/user/IFXUserInfoEdit.vue`](diffhunk://#diff-4835b53b8c3974fc062cd04552bb883d6a24f06d9339cc831b5f4f96f26663b2R158-R180): Added a new `v-autocomplete` field for selecting the user's primary affiliation, utilizing the `orgSlugs` array.

Code simplification:

* [`src/mixins/IFXMixin.js`](diffhunk://#diff-d070d1c8168568d987d49d59c3fda077c2f4b2b1716bae3e55bfac830f8aea93L84-R88): Simplified the code by removing unnecessary line breaks in method chains. [[1]](diffhunk://#diff-d070d1c8168568d987d49d59c3fda077c2f4b2b1716bae3e55bfac830f8aea93L84-R88) [[2]](diffhunk://#diff-d070d1c8168568d987d49d59c3fda077c2f4b2b1716bae3e55bfac830f8aea93L116-R114) [[3]](diffhunk://#diff-d070d1c8168568d987d49d59c3fda077c2f4b2b1716bae3e55bfac830f8aea93L318-R316)