### PR TITLE
Add getter for `ifxacct` to `IFXAccount`

### DIFF
--- a/src/components/account/IFXAccount.js
+++ b/src/components/account/IFXAccount.js
@@ -95,6 +95,10 @@ export class Account extends IFXItemBase {
     return this.data.slug
   }
 
+  get ifxacct() {
+    return this.data.ifxacct
+  }
+
   get created() {
     return this.data.created
   }


### PR DESCRIPTION
This PR adds a getter for `ifxacct` to the `Account` object. To get a NEMO Project, we need to send a unique ID for the NICE Account so `ifxacct` is used. This change allows the front-end to access that value.