### PR TITLE
Have all canceled reservations be grey

### DIFF
--- a/src/components/calendar/IFXCalendarList.vue
+++ b/src/components/calendar/IFXCalendarList.vue
@@ -244,6 +244,10 @@ export default {
       this.$api.storage.setItem('calendarType', type, 'local')
     },
     getEventColor(event) {
+      // Canceled events should always be grey
+      if (event.cancelled) {
+        return 'blue-grey lighten-3'
+      }
       if (this.useMaintenance && event.reservation.isMaintenance) {
         return this.$api.reservation.getMaintenanceColor()
       }
@@ -270,9 +274,6 @@ export default {
     },
     getResourceColor(RU) {
       const resId = RU.product.id
-      if (RU.cancelled) {
-        return 'blue-grey lighten-3'
-      }
       const theResource = this.allResources.find((resource) => resource.id === resId)
       return theResource ? theResource.color : 'grey'
     },


### PR DESCRIPTION
This PR changes how canceled Test/Pilot and Maintenance appear. They were still their normal colour even when canceled but now they will be `blue-grey lighten-3` so they are visually the same as canceled normal reservations.