### PR TITLE
Fix Project Request status display and display approvers

### DIFF
--- a/src/components/request/IFXAccountRequestTrackDetail.vue
+++ b/src/components/request/IFXAccountRequestTrackDetail.vue
@@ -63,7 +63,12 @@ export default {
         <span class="title">{{ trackTitle }}</span>
       </v-flex>
       <v-flex v-for="field in accountRequestData.tracks[track].fields.order" :key="field">
-        <v-layout row wrap v-if="accountRequestData.tracks[track].fields[field] && !['mou', 'po'].includes(field)" justify-start>
+        <v-layout
+          row
+          wrap
+          v-if="accountRequestData.tracks[track].fields[field] && !['mou', 'po'].includes(field)"
+          justify-start
+        >
           <v-flex class="field-label" xs12 md3 v-if="accountRequestData.tracks[track].fields[field].display_name">
             {{ accountRequestData.tracks[track].fields[field].display_name }}
           </v-flex>
@@ -72,7 +77,16 @@ export default {
           </v-flex>
           <v-flex xs12 md9 v-if="accountRequestData.tracks[track].fields[field].display_component">
             <component
-              v-if="['harvard_key', 'project', 'scientific_area', 'expense_code', 'terms_and_conditions', 'nnin_admin_username'].includes(field)"
+              v-if="
+                [
+                  'harvard_key',
+                  'project',
+                  'scientific_area',
+                  'expense_code',
+                  'terms_and_conditions',
+                  'nnin_admin_username',
+                ].includes(field)
+              "
               :is="accountRequestData.tracks[track].fields[field].display_component"
               :data="accountRequestData[field]"
             ></component>
@@ -84,7 +98,12 @@ export default {
               @change="updateData()"
             ></component>
             <component
-              v-else-if="['demographic_data', 'primary_affiliation'].includes(field)"
+              v-else-if="['primary_affiliation'].includes(field)"
+              :is="accountRequestData.tracks[track].fields[field].display_component"
+              :data="accountRequestData"
+            ></component>
+            <component
+              v-else-if="['demographic_data'].includes(field)"
               :is="accountRequestData.tracks[track].fields[field].display_component"
               :data="accountRequestData.person"
             ></component>

--- a/src/components/request/IFXDisplayAffiliations.vue
+++ b/src/components/request/IFXDisplayAffiliations.vue
@@ -5,14 +5,14 @@ export default {
   methods: {
     affiliationNames() {
       const names = []
-      this.data.affiliations.forEach((affiliation) => {
-        if (affiliation.slug !== this.data.primary_affiliation) {
+      this.data.person.affiliations.forEach((affiliation) => {
+        if (affiliation.slug !== this.data.person.primary_affiliation) {
           names.push(this.$options.filters.orgNameFromSlug(affiliation.slug))
         }
       })
       return names.join(', ')
     },
-  }
+  },
 }
 </script>
 <template>
@@ -21,21 +21,33 @@ export default {
       <v-layout column>
         <v-flex>
           <v-layout row>
-            <v-flex xs4>
-              Primary
-            </v-flex>
+            <v-flex xs4>Primary</v-flex>
             <v-flex>
-              {{ data.primary_affiliation | orgNameFromSlug }}
+              {{ data.person.primary_affiliation | orgNameFromSlug }}
             </v-flex>
           </v-layout>
         </v-flex>
-        <v-flex v-if="data.affiliations.length && data.affiliations.length > 1">
+        <v-flex v-if="data.person.affiliations.length && data.person.affiliations.length > 1">
           <v-layout row>
-            <v-flex xs4>
-              Others
-            </v-flex>
-            <v-flex>
+            <v-flex xs4>Others</v-flex>
+            <v-flex xs7>
               {{ affiliationNames() }}
+            </v-flex>
+          </v-layout>
+        </v-flex>
+        <v-flex>
+          <v-layout column>
+            <v-flex>
+              <v-layout row>
+                <v-flex xs4>Approvers</v-flex>
+                <v-flex v-if="data.approver_contacts.length > 0" xs7>
+                  <span v-for="(approver, index) in data.approver_contacts" :key="index">
+                    <a :href="`mailto:${approver}`">{{ approver }}</a>
+                    <span v-if="index < data.approver_contacts.length - 1">,&nbsp;</span>
+                  </span>
+                </v-flex>
+                <v-flex v-else>No approvers specified</v-flex>
+              </v-layout>
             </v-flex>
           </v-layout>
         </v-flex>

--- a/src/components/request/IFXDisplayLabInfo.vue
+++ b/src/components/request/IFXDisplayLabInfo.vue
@@ -1,5 +1,4 @@
 <script>
-
 export default {
   name: 'IFXDisplayLabInfo',
   props: {
@@ -27,13 +26,23 @@ export default {
       return true // This is needed to make the v-text-field work.  Don't know why
     },
   },
+  computed: {
+    hasLabInfo() {
+      return this.data && this.data.lab_info && this.data.lab_info.lab_name
+    },
+    hasLabApprovers() {
+      return this.data && this.data.lab_info && this.data.lab_info.approvers?.length
+    },
+  },
   mounted: function () {
     if (this.data?.lab_info?.organization?.contacts) {
-      const piOrgContact = this.data.lab_info.organization.contacts.find(orgContact => orgContact.role === 'PI')
+      const piOrgContact = this.data.lab_info.organization.contacts.find((orgContact) => orgContact.role === 'PI')
       if (piOrgContact) {
         this.piContact = piOrgContact.contact
       }
-      const billingOrgContact = this.data.lab_info.organization.contacts.find(orgContact => orgContact.role === 'Billing')
+      const billingOrgContact = this.data.lab_info.organization.contacts.find(
+        (orgContact) => orgContact.role === 'Billing'
+      )
       if (billingOrgContact) {
         this.billingContact = billingOrgContact.contact
       }
@@ -45,13 +54,11 @@ export default {
   <v-layout column>
     <v-flex>
       <v-layout>
-        <v-flex v-if="data && data.lab_info && data.lab_info.lab_name">
+        <v-flex v-if="hasLabInfo">
           <v-layout column>
             <v-flex>
               <v-layout row>
-                <v-flex xs4>
-                  Lab / Company Name
-                </v-flex>
+                <v-flex xs4>Lab / Company Name</v-flex>
                 <v-flex>
                   {{ data.lab_info.lab_name }}
                 </v-flex>
@@ -61,11 +68,10 @@ export default {
           <v-layout column>
             <v-flex>
               <v-layout row align-center>
-                <v-flex xs4>
-                  Selected Organization
-                </v-flex>
+                <v-flex xs4>Selected Organization</v-flex>
                 <v-flex>
-                  <v-autocomplete v-if="organizations"
+                  <v-autocomplete
+                    v-if="organizations"
                     v-model.trim="data.lab_info.organization"
                     :items="organizations"
                     item-text="name"
@@ -76,22 +82,30 @@ export default {
               </v-layout>
             </v-flex>
           </v-layout>
+          <v-layout column>
+            <v-flex>
+              <v-layout row>
+                <v-flex xs4>Lab Approvers</v-flex>
+                <v-flex v-if="hasLabApprovers">
+                  <span v-for="(approver, index) in data.lab_info.approvers" :key="index">
+                    <a :href="`mailto:${approver}`">{{ approver }}</a>
+                    <span v-if="index < data.lab_info.approvers.length - 1">,</span>
+                  </span>
+                </v-flex>
+                <v-flex v-else>No approvers specified</v-flex>
+              </v-layout>
+            </v-flex>
+          </v-layout>
           <v-layout v-if="Object.keys(piContact).length === 0" column>
             <v-flex>
               <v-layout row>
-                <v-flex xs4>
-                  PI / Manager
-                </v-flex>
-                <v-flex>
-                  {{ data.lab_info.pi_name }}, {{ data.lab_info.pi_email }}
-                </v-flex>
+                <v-flex xs4>PI / Manager</v-flex>
+                <v-flex>{{ data.lab_info.pi_name }}, {{ data.lab_info.pi_email }}</v-flex>
               </v-layout>
             </v-flex>
             <v-flex>
               <v-layout row>
-                <v-flex xs4>
-                  &nbsp;
-                </v-flex>
+                <v-flex xs4>&nbsp;</v-flex>
                 <v-flex>
                   {{ data.lab_info.pi_street1 }}
                 </v-flex>
@@ -99,9 +113,7 @@ export default {
             </v-flex>
             <v-flex>
               <v-layout row>
-                <v-flex xs4>
-                  &nbsp;
-                </v-flex>
+                <v-flex xs4>&nbsp;</v-flex>
                 <v-flex>
                   {{ data.lab_info.pi_city }}, {{ data.lab_info.pi_state }} {{ data.lab_info.pi_postal_code }}
                 </v-flex>
@@ -109,9 +121,7 @@ export default {
             </v-flex>
             <v-flex v-if="data.lab_info.pi_contact_country != 'United States'">
               <v-layout row>
-                <v-flex xs4>
-                  &nbsp;
-                </v-flex>
+                <v-flex xs4>&nbsp;</v-flex>
                 <v-flex>
                   {{ data.lab_info.pi_contact_country }}
                 </v-flex>
@@ -119,9 +129,7 @@ export default {
             </v-flex>
             <v-flex>
               <v-layout row>
-                <v-flex xs4>
-                  &nbsp;
-                </v-flex>
+                <v-flex xs4>&nbsp;</v-flex>
                 <v-flex>
                   {{ data.lab_info.pi_phone }}
                 </v-flex>
@@ -131,21 +139,15 @@ export default {
           <v-layout v-else column>
             <v-flex>
               <v-layout row>
-                <v-flex xs4>
-                  PI / Manager
-                </v-flex>
-                <v-flex>
-                  {{ piContact.name }}, {{ piContact.detail }}
-                </v-flex>
+                <v-flex xs4>PI / Manager</v-flex>
+                <v-flex>{{ piContact.name }}, {{ piContact.detail }}</v-flex>
               </v-layout>
             </v-flex>
             <v-flex>
               <v-layout row>
-                <v-flex xs4>
-                  &nbsp;
-                </v-flex>
+                <v-flex xs4>&nbsp;</v-flex>
                 <v-flex class="address">
-                  {{ piContact.address}}
+                  {{ piContact.address }}
                 </v-flex>
               </v-layout>
             </v-flex>
@@ -153,20 +155,17 @@ export default {
           <v-layout v-if="Object.keys(billingContact).length === 0" column>
             <v-flex>
               <v-layout row>
-                <v-flex xs4>
-                  Billing Contact
-                </v-flex>
+                <v-flex xs4>Billing Contact</v-flex>
                 <v-flex>
                   <span v-if="data.lab_info.billing_contact_name">{{ data.lab_info.billing_contact_name }}</span>
-                  <span v-else>{{ data.lab_info.pi_name }}</span>, {{ data.lab_info.billing_contact_email }}
+                  <span v-else>{{ data.lab_info.pi_name }}</span>
+                  , {{ data.lab_info.billing_contact_email }}
                 </v-flex>
               </v-layout>
             </v-flex>
             <v-flex>
               <v-layout row>
-                <v-flex xs4>
-                  &nbsp;
-                </v-flex>
+                <v-flex xs4>&nbsp;</v-flex>
                 <v-flex>
                   {{ data.lab_info.billing_contact_street1 }}
                 </v-flex>
@@ -174,19 +173,16 @@ export default {
             </v-flex>
             <v-flex>
               <v-layout row>
-                <v-flex xs4>
-                  &nbsp;
-                </v-flex>
+                <v-flex xs4>&nbsp;</v-flex>
                 <v-flex>
-                  {{ data.lab_info.billing_contact_city }}, {{ data.lab_info.billing_contact_state }} {{ data.lab_info.billing_contact_postal_code }}
+                  {{ data.lab_info.billing_contact_city }}, {{ data.lab_info.billing_contact_state }}
+                  {{ data.lab_info.billing_contact_postal_code }}
                 </v-flex>
               </v-layout>
             </v-flex>
             <v-flex v-if="data.lab_info.billing_contact_country != 'United States'">
               <v-layout row>
-                <v-flex xs4>
-                  &nbsp;
-                </v-flex>
+                <v-flex xs4>&nbsp;</v-flex>
                 <v-flex>
                   {{ data.lab_info.billing_contact_country }}
                 </v-flex>
@@ -194,9 +190,7 @@ export default {
             </v-flex>
             <v-flex>
               <v-layout row>
-                <v-flex xs4>
-                  &nbsp;
-                </v-flex>
+                <v-flex xs4>&nbsp;</v-flex>
                 <v-flex>
                   {{ data.lab_info.billing_contact_phone }}
                 </v-flex>
@@ -206,19 +200,13 @@ export default {
           <v-layout v-else column>
             <v-flex>
               <v-layout row>
-                <v-flex xs4>
-                  Billing Contact
-                </v-flex>
-                <v-flex>
-                  {{ billingContact.name }}, {{ billingContact.detail }}
-                </v-flex>
+                <v-flex xs4>Billing Contact</v-flex>
+                <v-flex>{{ billingContact.name }}, {{ billingContact.detail }}</v-flex>
               </v-layout>
             </v-flex>
             <v-flex>
               <v-layout row>
-                <v-flex xs4>
-                  &nbsp;
-                </v-flex>
+                <v-flex xs4>&nbsp;</v-flex>
                 <v-flex class="address">
                   {{ billingContact.address }}
                 </v-flex>
@@ -231,7 +219,7 @@ export default {
   </v-layout>
 </template>
 <style scoped>
-  .address {
-    white-space: pre-line;
-  }
+.address {
+  white-space: pre-line;
+}
 </style>

--- a/src/components/request/IFXDisplayProject.vue
+++ b/src/components/request/IFXDisplayProject.vue
@@ -12,9 +12,7 @@ export default {
           <v-layout column>
             <v-flex>
               <v-layout row>
-                <v-flex xs4>
-                  Title
-                </v-flex>
+                <v-flex xs4>Title</v-flex>
                 <v-flex>
                   {{ data.title }}
                 </v-flex>
@@ -24,11 +22,9 @@ export default {
           <v-layout column>
             <v-flex>
               <v-layout row>
-                <v-flex xs4>
-                  Status
-                </v-flex>
+                <v-flex xs4>Current State</v-flex>
                 <v-flex>
-                  {{ data.status }}
+                  {{ data.current_state | stateDisplay }}
                 </v-flex>
               </v-layout>
             </v-flex>
@@ -36,9 +32,7 @@ export default {
           <v-layout column>
             <v-flex>
               <v-layout row>
-                <v-flex xs4>
-                  Estimated Start Date
-                </v-flex>
+                <v-flex xs4>Estimated Start Date</v-flex>
                 <v-flex>
                   {{ data.estimated_start_date }}
                 </v-flex>
@@ -48,9 +42,7 @@ export default {
           <v-layout column>
             <v-flex>
               <v-layout row>
-                <v-flex xs4>
-                  Estimated duration
-                </v-flex>
+                <v-flex xs4>Estimated duration</v-flex>
                 <v-flex>
                   {{ data.estimated_duration }}
                 </v-flex>


### PR DESCRIPTION
This PR updates how Approvers are displayed on the Account Request page. The `approver_contacts` are displayed next to the "other" affiliations in the **Affiliations** section. Also, the `status` of the Project Request has been changed to `state`