### PR TITLE
Change how "Show Inactive" control appears

### DIFF
--- a/src/components/contact/IFXAffiliationRoleDisplayEdit.vue
+++ b/src/components/contact/IFXAffiliationRoleDisplayEdit.vue
@@ -73,7 +73,11 @@ export default {
       </span>
       <span class="ml-2">of {{ affiliation.organization | orgNameFromSlug }}</span>
     </v-col>
-    <v-col md="8" v-else-if="showInactive || itemLocal.active" :class="{ 'text-decoration-line-through': !itemLocal.active }">
+    <v-col
+      md="8"
+      v-else-if="showInactive || itemLocal.active"
+      :class="{ 'text-decoration-line-through': !itemLocal.active }"
+    >
       <span>{{ affiliation.role | affiliationRoleDisplay }} of {{ affiliation.organization | orgNameFromSlug }}</span>
     </v-col>
     <v-col v-if="$api.auth.can('edit-affiliations')" md="4">
@@ -93,7 +97,7 @@ export default {
         </template>
         <span>Deactivate affiliation</span>
       </v-tooltip>
-      <v-tooltip v-else-if="showInactive">
+      <v-tooltip v-else-if="showInactive" top>
         <template v-slot:activator="{ on, attrs }">
           <v-icon
             v-on="on"

--- a/src/components/user/IFXUserDetail.vue
+++ b/src/components/user/IFXUserDetail.vue
@@ -267,13 +267,13 @@ export default {
     },
     userCategoriesToDisplay() {
       // Assume all categories are allowed
-      const categories = this.userFilesCategories.map((c) => c.name)
+      let categories = this.userFilesCategories.map((c) => c.name)
       // If we're only allowed one file per category, filter out categories that already have files
       if (categories.length && this.onlyOneFilePerCategory) {
         // Get all the existing categories in a set so they will be unique
         const existingCategories = new Set(Object.keys(this.userCategories))
         // Filter out any categories that already exist
-        return categories.filter((category) => !existingCategories.has(category))
+        categories = categories.filter((category) => !existingCategories.has(category))
       }
       return this.showPhotoInUserFiles ? categories : categories.filter((category) => category !== 'User Photo')
     },
@@ -482,7 +482,7 @@ export default {
           <v-col v-if="hasUserFiles()">
             <div v-for="category in Object.keys(userCategories)" :key="category">
               <span v-if="onlyOneFilePerCategory">
-                <v-row v-for="file in userCategories[category]" :key="`${category}${file.id}`">
+                <v-row dense v-for="file in userCategories[category]" :key="`${category}${file.id}`">
                   <v-col sm="12">
                     <div>
                       <span class="font-weight-medium">{{ category }}:&nbsp;</span>
@@ -511,7 +511,7 @@ export default {
                   <span class="ml-1">{{ category }}s</span>
                 </summary>
                 <span>
-                  <v-row v-for="file in userCategories[category]" :key="`${category}${file.id}`">
+                  <v-row dense v-for="file in userCategories[category]" :key="`${category}${file.id}`">
                     <v-col sm="11">
                       <div class="ml-4">
                         <a :href="file.file" target="_blank">{{ file.file | fileNameFromUrl }}</a>
@@ -845,12 +845,9 @@ export default {
   font-style: italic;
   color: grey;
 }
-::v-deep .small-checkbox {
+.small-checkbox {
   .v-messages {
     display: none;
-  }
-  .v-label {
-    font-size: 8px;
   }
 }
 </style>

--- a/src/components/user/IFXUserDetail.vue
+++ b/src/components/user/IFXUserDetail.vue
@@ -82,23 +82,10 @@ export default {
       newUserFile: {},
       fileToDelete: {},
       showInactiveAffiliations: false,
-      affiliationRoleDisplayKeys: [],
       showInactiveAccounts: false,
-
     }
   },
-  watch: {
-    showInactiveAffiliations() {
-      this.affiliationRoleDisplayKeys.forEach((v, i, arr) => {
-        arr[i] = v + 1
-      })
-    },
-  },
-  mounted() {
-    this.item.affiliations.forEach(() => {
-      this.affiliationRoleDisplayKeys.push(0)
-    })
-  },
+  mounted() {},
   methods: {
     ...mapActions(['showMessage']),
     async getAdditionalData() {
@@ -288,7 +275,7 @@ export default {
         // Filter out any categories that already exist
         return categories.filter((category) => !existingCategories.has(category))
       }
-      return this.showPhotoInUserFiles ? categories.filter((category) => category !== 'User Photo') : categories
+      return this.showPhotoInUserFiles ? categories : categories.filter((category) => category !== 'User Photo')
     },
   },
 }
@@ -461,12 +448,14 @@ export default {
         <v-row dense>
           <v-col sm="3" md="3">
             <h3>Other Affiliations</h3>
+            <div>
+              <v-switch v-model="showInactiveAffiliations" label="Show Inactive" class="small-checkbox mt-0"></v-switch>
+            </div>
           </v-col>
           <v-col>
             <span class="d-flex flex-column">
               <div v-for="(affiliation, index) in item.affiliations" :key="index" class="d-flex align-center mt-1">
                 <IFXAffiliationRoleDisplayEdit
-                  :key="affiliationRoleDisplayKeys[index]"
                   :affiliation="affiliation"
                   :showInactive="showInactiveAffiliations"
                   @update="updateAffiliation(affiliation, index)"
@@ -475,23 +464,12 @@ export default {
             </span>
           </v-col>
           <v-col sm="2" align="end">
-            <v-row dense justify="center" align="center" nowrap>
-             <v-col class="flex-grow-1 flex-shrink-0">
-                <v-checkbox
-                  v-model="showInactiveAffiliations"
-                  label="Show Inactive"
-                  class="small-checkbox"
-                ></v-checkbox>
-              </v-col>
-              <v-col class="flex-grow-0 flex-shrink-1">
-                <v-tooltip top v-if="isUserInfoEdittable">
-                  <template v-slot:activator="{ on, attrs }">
-                    <IFXButton v-on="on" v-bind="attrs" btnType="add" xSmall @action="openAffiliationDialog()" />
-                  </template>
-                  <span>Add affiliation</span>
-                </v-tooltip>
-              </v-col>
-             </v-row>
+            <v-tooltip top v-if="isUserInfoEdittable">
+              <template v-slot:activator="{ on, attrs }">
+                <IFXButton v-on="on" v-bind="attrs" btnType="add" xSmall @action="openAffiliationDialog()" />
+              </template>
+              <span>Add affiliation</span>
+            </v-tooltip>
           </v-col>
         </v-row>
       </span>
@@ -576,11 +554,15 @@ export default {
       <v-row dense v-if="areAnyAccountsPresent">
         <v-col sm="4" md="3">
           <h3>Expense code / PO Authorizations</h3>
+          <div>
+            <v-switch v-model="showInactiveAccounts" label="Show Inactive" class="small-checkbox mt-0"></v-switch>
+          </div>
         </v-col>
         <v-col>
           <span v-if="areAccountsPresent" class="d-flex flex-column">
             <div v-for="account in item.accounts" :key="account.id" class="d-flex align-center mt-1">
-              <span v-if="showInactiveAccounts || (account.data.is_valid && account.account.active)"
+              <span
+                v-if="showInactiveAccounts || (account.data.is_valid && account.account.active)"
                 :class="{
                   'text-decoration-line-through':
                     $api.auth.can('see-inactive-accounts') && !(account.data.is_valid && account.account.active),
@@ -592,7 +574,8 @@ export default {
           </span>
           <span v-if="areProductAccountsPresent" class="d-flex flex-column">
             <div v-for="account in item.productAccounts" :key="account.id" class="d-flex align-center mt-1">
-              <span  v-if="showInactiveAccounts || (account.data.is_valid && account.account.active)"
+              <span
+                v-if="showInactiveAccounts || (account.data.is_valid && account.account.active)"
                 :class="{
                   'text-decoration-line-through':
                     $api.auth.can('see-inactive-accounts') && !(account.data.is_valid && account.account.active),
@@ -605,20 +588,6 @@ export default {
               </span>
             </div>
           </span>
-        </v-col>
-        <v-col sm="2" align="end">
-          <v-row dense justify="center" align="center" nowrap>
-            <v-col class="flex-grow-1 flex-shrink-0">
-            <v-checkbox
-              v-model="showInactiveAccounts"
-              label="Show Inactive"
-              class="small-checkbox"
-            ></v-checkbox>
-            </v-col>
-            <v-col class="flex-grow-0 flex-shrink-1">
-              <IFXButton btnType="add" xSmall style="visibility: hidden;"/> <!-- Placeholder for alignment -->
-            </v-col>
-            </v-row>
         </v-col>
       </v-row>
       <slot name="additionalItems" :item="item"></slot>
@@ -857,7 +826,7 @@ export default {
   </v-container>
 </template>
 
-<style>
+<style lang="scss">
 .action-item {
   display: flex;
   justify-content: space-between;
@@ -876,7 +845,12 @@ export default {
   font-style: italic;
   color: grey;
 }
-::v-deep .small-checkbox .v-label {
-  font-size: 8px;
+::v-deep .small-checkbox {
+  .v-messages {
+    display: none;
+  }
+  .v-label {
+    font-size: 8px;
+  }
 }
 </style>


### PR DESCRIPTION
This PR changes the "Show Inactive" control from a checkbox on the right side of the page to a switch on the left under the heading/title of the section and removes the keys that caused redraw of the child components.

Plus it fixed the bug where the _User Photo_ User File category would show up in the "add user file" dialog when it shouldn't.
