### PR TITLE
Check account/PO expiration when reserving in `IFXCalendarList`

### DIFF
--- a/src/components/calendar/IFXCalendarList.vue
+++ b/src/components/calendar/IFXCalendarList.vue
@@ -911,6 +911,26 @@ export default {
     revalidateTimes() {
       this.$refs.startDate.validate(true)
       this.$refs.endDate.validate(true)
+      this.setApprovalBasedOnExpenseCode(true)
+    },
+    showExpenseCodeMsg(event) {
+      return !this.$api.reservation.willExpenseCodeStillBeValid(
+        // Only check the first account since we don't allow splits
+        event.reservation.accounts[0].account,
+        this.allowedExpenseCodes,
+        event.startDate,
+        event.endDate,
+        false
+      )
+    },
+    setApprovalBasedOnExpenseCode() {
+      this.approved = this.$api.reservation.willExpenseCodeStillBeValid(
+        this.expenseCode,
+        this.allowedExpenseCodes,
+        this.newEvent.startDate,
+        this.newEvent.endDate,
+        true
+      )
     },
   },
   watch: {
@@ -1157,6 +1177,7 @@ export default {
                     :rules="[isBillableRule]"
                     :disabled="resourceNotSelected || !expenseCodeEnabled"
                     data-cy="expense-code"
+                    @change="setApprovalBasedOnExpenseCode(true)"
                   >
                     <template #no-data>
                       <div class="mx-3 my-1">No expense code or PO found for this organization and resource</div>
@@ -1243,7 +1264,7 @@ export default {
                       </v-autocomplete>
                     </v-col>
                   </v-row>
-                  <v-row>
+                  <v-row dense>
                     <v-col>
                       <div class="text-divider font-italic text-center">Or set End time directly</div>
                     </v-col>
@@ -1608,6 +1629,13 @@ export default {
                   data-cy="popup-special-message"
                 >
                   {{ $api.reservation.getSpecialMessage() }}
+                </div>
+                <div
+                  v-if="showExpenseCodeMsg(selectedEvent, false)"
+                  class="mt-2 red--text"
+                  data-cy="popup-expired-message"
+                >
+                  The selected expense code/PO will not be valid for the selected reservation time.
                 </div>
                 <div v-if="selectedEvent.cancelled" class="mt-2 red--text" data-cy="popup-cancelled">
                   This reservation is cancelled.

--- a/src/components/calendar/IFXCalendarList.vue
+++ b/src/components/calendar/IFXCalendarList.vue
@@ -918,6 +918,9 @@ export default {
       this.setApprovalBasedOnExpenseCode(true)
     },
     showExpenseCodeMsg(event) {
+      if (!event.reservation.accounts || event.reservation.accounts.length === 0) {
+        return false
+      }
       return !this.willExpenseCodeStillBeValid(
         // Only check the first account since we don't allow splits
         event.reservation.accounts[0].account,

--- a/src/components/calendar/IFXCalendarList.vue
+++ b/src/components/calendar/IFXCalendarList.vue
@@ -550,6 +550,7 @@ export default {
       // Check if there are two green-badged people, including the reserver
       // Put up a warning if not.
       const useSpecialMsg = this.$api.reservation.useSpecialMsg(this.resource, this.attendants)
+      const showExpenseCodeMsg = this.showExpenseCodeMsg(this.newEvent)
 
       if (this.newEvent.id) {
         // This is an existing event. Replace it
@@ -560,6 +561,9 @@ export default {
           let msg = `Updated reservation of ${resUsage.product.name} for ${resUsage.productUser.fullName}.`
           if (useSpecialMsg) {
             msg += ` ${this.$api.reservation.getSpecialMessage()}`
+          }
+          if (showExpenseCodeMsg) {
+            msg += ` ${this.getExpiredAccountMessage()}`
           }
           this.showMessage(msg)
           const returnedRU = await this.$api.reservationUsage.create(res.data)
@@ -914,23 +918,47 @@ export default {
       this.setApprovalBasedOnExpenseCode(true)
     },
     showExpenseCodeMsg(event) {
-      return !this.$api.reservation.willExpenseCodeStillBeValid(
+      return !this.willExpenseCodeStillBeValid(
         // Only check the first account since we don't allow splits
         event.reservation.accounts[0].account,
-        this.allowedExpenseCodes,
         event.startDate,
         event.endDate,
         false
       )
     },
     setApprovalBasedOnExpenseCode() {
-      this.approved = this.$api.reservation.willExpenseCodeStillBeValid(
+      this.approved = this.willExpenseCodeStillBeValid(
         this.expenseCode,
-        this.allowedExpenseCodes,
         this.newEvent.startDate,
         this.newEvent.endDate,
         true
       )
+    },
+    willExpenseCodeStillBeValid(expenseCode, startDate, endDate, showMessage = false) {
+      // Check if there is an existing expense code selected and, if so, make sure it will still be valid
+      // during this reservation. If the code will have expired, force approval
+      let isValid = true
+      if (expenseCode) {
+        const matchedCode = this.allowedExpenseCodes.find((code) => code.slug === expenseCode)
+
+        if (matchedCode && startDate && endDate) {
+          const startDateTime = new Date(startDate).getTime()
+          const endDateTime = new Date(endDate).getTime()
+          if (
+            startDateTime < new Date(matchedCode.validFrom).getTime()
+            || endDateTime > new Date(matchedCode.expirationDate).getTime()
+          ) {
+            isValid = false
+          }
+        }
+      }
+      if (!isValid && showMessage) {
+        this.showMessage(`${this.getExpiredAccountMessage()} The reservation has been marked as needing approval.`)
+      }
+      return isValid
+    },
+    getExpiredAccountMessage() {
+      return 'The selected account will not be valid for the selected reservation time.'
     },
   },
   watch: {
@@ -1630,12 +1658,8 @@ export default {
                 >
                   {{ $api.reservation.getSpecialMessage() }}
                 </div>
-                <div
-                  v-if="showExpenseCodeMsg(selectedEvent, false)"
-                  class="mt-2 red--text"
-                  data-cy="popup-expired-message"
-                >
-                  The selected expense code/PO will not be valid for the selected reservation time.
+                <div v-if="showExpenseCodeMsg(selectedEvent)" class="mt-2 red--text" data-cy="popup-expired-message">
+                  {{ getExpiredAccountMessage() }}
                 </div>
                 <div v-if="selectedEvent.cancelled" class="mt-2 red--text" data-cy="popup-cancelled">
                   This reservation is cancelled.


### PR DESCRIPTION
This pull request enhances the calendar reservation system by introducing improved validation and messaging for expense code expiration. The changes ensure that users are notified if the selected expense code will not be valid during the reservation period, and the approval status is set accordingly. The most important changes are grouped below:

Expense Code Validation and Messaging:

* Added the `showExpenseCodeMsg` method and related logic to check if the selected expense code will be valid for the reservation time, displaying a warning message if not. [[1]](diffhunk://#diff-678088fdfef5986b29cf6245b43cfb79e2c5a820a2f24f0bd979ce82719b8970R918-R961) [[2]](diffhunk://#diff-678088fdfef5986b29cf6245b43cfb79e2c5a820a2f24f0bd979ce82719b8970R553) [[3]](diffhunk://#diff-678088fdfef5986b29cf6245b43cfb79e2c5a820a2f24f0bd979ce82719b8970R565-R567)
* Implemented `setApprovalBasedOnExpenseCode` to automatically set the approval status based on the validity of the expense code, including triggering this logic when the expense code is changed. [[1]](diffhunk://#diff-678088fdfef5986b29cf6245b43cfb79e2c5a820a2f24f0bd979ce82719b8970R918-R961) [[2]](diffhunk://#diff-678088fdfef5986b29cf6245b43cfb79e2c5a820a2f24f0bd979ce82719b8970R1208)
* Added a user-facing message in the reservation popup when the selected expense code is expired, improving clarity for users.

UI Improvements:

* Changed the calendar UI to use a denser row layout for the end time selector, improving visual consistency.