### PR TITLE
V3 migration ajk

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "segfault-handler": "^1.3.0",
     "terser": "^5.40.0",
     "vue": "^3.4.0",
-    "vuetify": "^3.5.0",
+    "vuetify": "^3.10.9",
     "vuex": "^4.1.0"
   },
   "devDependencies": {

--- a/src/api/IFXAPI.js
+++ b/src/api/IFXAPI.js
@@ -42,7 +42,7 @@ export default class IFXAPIService {
     this._store = store
     this._axios = axios.create()
     this._authUser = null
-    this.urls = urls
+    this._urls = urls
     // We want to auto-clear the cache every 4 hours
     let cacheTimer = this.storage.getItem('cacheTimer', 'session')
     if (cacheTimer) {
@@ -64,7 +64,7 @@ export default class IFXAPIService {
   }
 
   get urls() {
-    return this.urls
+    return this._urls
   }
 
   get vars() {

--- a/src/plugins/vuetify-local.js
+++ b/src/plugins/vuetify-local.js
@@ -2,8 +2,12 @@
 import { createVuetify } from 'vuetify'
 import 'material-design-icons-iconfont/dist/material-design-icons.css'
 import '@mdi/font/css/materialdesignicons.css'
+import { VCalendar } from 'vuetify/labs/VCalendar'
 
 export default createVuetify({
+  components: {
+    VCalendar,
+  },
   theme: {
     defaultTheme: 'light',
     themes: {


### PR DESCRIPTION
Updated vuetify to 3.10
Explicitly add VCalendar because it is in "labs" now
Don't need store for urls