### PR TITLE
getCurrentUserRecord should use getById

### DIFF
--- a/src/api/IFXAPI.js
+++ b/src/api/IFXAPI.js
@@ -173,14 +173,10 @@ export default class IFXAPIService {
       isStaff: this.authUser ? this.authUser.isStaff : false,
       // Returns the record for the user that is currently authenticated
       getCurrentUserRecord: async () => {
-        const username = this.authUser.username
-        const users = await this.user.getList({ username })
+        const user = await this.user.getByID(this.authUser.id)
         // TODO switch from console errors to returned errors
-        if (users.length > 1) {
-          console.error('Cannot have more than one returned user')
-        }
-        if (users.length && users.length >= 1) {
-          return users[0]
+        if (user) {
+          return user
         }
         console.error('No user found')
         return null


### PR DESCRIPTION
To free up getUserList a bit, getCurrentUserRecord should return the object using getById.  Fiine needs this so it can filter out affiliations.

get_remote_user_auth_token may need to be modified to include the id.