### PR TITLE
In the popup card displayed for a reservation, show `name` of PO rather than `code`

### DIFF
--- a/src/components/calendar/IFXCalendarList.vue
+++ b/src/components/calendar/IFXCalendarList.vue
@@ -857,7 +857,7 @@ export default {
     getAccountDisplay(item) {
       // Return a list of the friendly names of the accounts
       return item.reservation.accounts
-        .map(({ account }) => {
+        .map(({ account, name }) => {
           let result = account
           if (account) {
             // parse a slug
@@ -865,7 +865,8 @@ export default {
             if (match.length) {
               // If the first three characters are "PO<space>", we've got a PO
               if (match[1].startsWith('PO ')) {
-                result = match[1].substr(3)
+                // If this is a PO, try to use the name rather than the slug
+                result = name || match[1].substr(3)
               } else {
                 result = match[2]
               }


### PR DESCRIPTION
This PR changes how the expense code is displayed on the popup card in the calendar.  If this is a PO, we now show the `name` of the account rather than the `code` (minus the `PO ` in the front). If there is no `name`, for some reason, we fall back to the old `code`