### PR TITLE
Allow editing the A/R Details for an organization

### DIFF
--- a/src/components/calendar/IFXCalendarList.vue
+++ b/src/components/calendar/IFXCalendarList.vue
@@ -185,7 +185,7 @@ export default {
         ? this.items.filter((item) => this.filteredResources.some((resource) => item.product.name === resource.name))
         : this.items
     },
-    cantBeEdited() {
+    cantEditTimeOrResource() {
       if (this.weAreEditing) {
         // This is editing an existing reservation. Check if it is editable
         return !this.canEditReservation(this.newEvent)
@@ -343,7 +343,7 @@ export default {
       nativeEvent.stopPropagation()
     },
     handleDayClick(calEvent) {
-      if (!this.cantBeEdited) {
+      if (!this.cantEditTimeOrResource) {
         this.setDefaultStartDate(calEvent.date)
       }
       this.reservationOpen = true
@@ -525,7 +525,7 @@ export default {
     },
     checkInPast(v) {
       return (
-        this.cantBeEdited // If the reservation can't be edited, don't bother checking if it's in the past
+        this.cantEditTimeOrResource // If the reservation can't be edited, don't bother checking if it's in the past
         || moment.tz(v, this.parseFormats, 'America/New_York').isAfter(moment.tz('America/New_York'))
         || this.$api.auth.can('add-reservations-in-the-past')
         || 'Cannot set reservations in the past'
@@ -1195,7 +1195,7 @@ export default {
                     v-model="organization"
                     :rules="formRules.generic"
                     @change="getAllExpenseCodes(user)"
-                    :disabled="cantBeEdited || resourceNotSelected"
+                    :disabled="cantEditTimeOrResource || resourceNotSelected"
                     data-cy="organizaton"
                   >
                     <template v-slot:item="{ item }">
@@ -1234,7 +1234,7 @@ export default {
                     persistent-hint
                     @click:prepend.stop="openPickers('startDate')"
                     :rules="[dateTimeRule, checkInPast, checkIsBeforeEnd]"
-                    :disabled="cantBeEdited || resourceNotSelected"
+                    :disabled="cantEditTimeOrResource || resourceNotSelected"
                     data-cy="start-date"
                   ></v-text-field>
                   <v-menu
@@ -1294,7 +1294,7 @@ export default {
                         :items="duration"
                         @change="setEndTime($event, true)"
                         class="my-2"
-                        :disabled="cantBeEdited || resourceNotSelected"
+                        :disabled="cantEditTimeOrResource || resourceNotSelected"
                         data-cy="length-select"
                       >
                         <template #no-data>
@@ -1320,7 +1320,7 @@ export default {
                     required
                     @click:prepend.stop="openPickers('endDate')"
                     :rules="[dateTimeRule, checkInPast, checkIsAfterStart, checkSpansMonth]"
-                    :disabled="cantBeEdited || resourceNotSelected"
+                    :disabled="cantEditTimeOrResource || resourceNotSelected"
                     data-cy="end-date"
                   ></v-text-field>
                   <v-menu
@@ -1409,7 +1409,7 @@ export default {
                     data-cy="comments"
                   ></v-textarea>
                   <!-- <v-checkbox
-                :disabled="cantBeEdited || resourceNotSelected"
+                :disabled="cantEditTimeOrResource || resourceNotSelected"
                 v-if="canSetRepeatingEvents()"
                 label="Repeating reservation"
                 v-model="isRepeatingReservation"
@@ -1548,7 +1548,7 @@ export default {
               <v-card-actions class="d-flex justify-space-between">
                 <v-btn text color="secondary" @click="clearReservation" data-cy="reservation-clear">Clear</v-btn>
                 <v-btn text color="primary" :disabled="!formIsValid" @click="reserveResource" data-cy="reservation-ok">
-                  {{ cantBeEdited ? 'Update' : 'Reserve' }}
+                  {{ cantEditTimeOrResource ? 'Update' : 'Reserve' }}
                 </v-btn>
               </v-card-actions>
             </v-card>

--- a/src/components/organization/IFXOrganizationDetail.vue
+++ b/src/components/organization/IFXOrganizationDetail.vue
@@ -28,9 +28,13 @@ export default {
       currentContact: {},
       contactDialogOpen: false,
       addContactFormIsValid: false,
+      arDetailsFormIsValid: false,
       showAddUserModal: false,
       showRevokeUserModal: false,
       showReactivateUserModal: false,
+      showAEditARModal: false,
+      customerId: null,
+      addressId: null,
       selected: [],
       selectedUsers: [],
       usersToBeUpdated: [],
@@ -99,6 +103,23 @@ export default {
         }
       })
       return indices
+    },
+    openARDetails() {
+      this.customerId = this.item.customerId
+      this.addressId = this.item.addressId
+      this.showAEditARModal = true
+    },
+    updateARDetails() {
+      // We only have two fields, so we can just update them directly on the item and submit the whole org
+      // instead of making a separate API call just for these details.
+      this.item.customerId = this.customerId || null
+      this.item.addressId = this.addressId || null
+      this.showAEditARModal = false
+    },
+    cancelARDetails() {
+      this.customerId = null
+      this.addressId = null
+      this.showAEditARModal = false
     },
     updateOrg(org) {
       this.item = org
@@ -209,26 +230,35 @@ export default {
           </v-col>
         </v-row>
         <v-row dense justify="start">
-          <v-col class="ml-4 field-label">
-            A/R Customer ID
-          </v-col>
+          <v-col class="ml-4 field-label">A/R Customer ID</v-col>
           <v-col>
             {{ item.customerId }}
           </v-col>
-          <v-col>
-            &nbsp;
+          <v-col align="end">
+            <v-tooltip top>
+              <template v-slot:activator="{ on }">
+                <v-btn
+                  class="ml-2"
+                  v-on="on"
+                  fab
+                  x-small
+                  color="primary"
+                  data-cy="edit-ar-details-modal"
+                  @click.stop="openARDetails()"
+                >
+                  <v-icon>mdi-pencil</v-icon>
+                </v-btn>
+              </template>
+              <span>Change A/R Details</span>
+            </v-tooltip>
           </v-col>
         </v-row>
         <v-row dense>
-          <v-col class="ml-4 field-label">
-            A/R Address ID
-          </v-col>
+          <v-col class="ml-4 field-label">A/R Address ID</v-col>
           <v-col>
             {{ item.addressId }}
           </v-col>
-          <v-col>
-            &nbsp;
-          </v-col>
+          <v-col>&nbsp;</v-col>
         </v-row>
       </v-col>
     </v-row>
@@ -420,6 +450,54 @@ export default {
           <v-btn small text class="mr-2" color="secondary" @click="cancelContact">Clear</v-btn>
           <v-btn small text class="mr-2" :disabled="!addContactFormIsValid" color="primary" @click="addContact()">
             Add
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+    <v-dialog v-model="showAEditARModal" v-if="showAEditARModal" max-width="600px" persistent>
+      <v-card>
+        <v-card-title>
+          Change A/R Details
+          <v-spacer></v-spacer>
+          <v-tooltip top>
+            <template v-slot:activator="{ on, attrs }">
+              <v-btn icon small @click="showAEditARModal = false" data-cy="ar-dialog-close" v-on="on" v-bind="attrs">
+                <v-icon>mdi-close</v-icon>
+              </v-btn>
+            </template>
+            <span>Cancel</span>
+          </v-tooltip>
+        </v-card-title>
+        <v-card-text class="pb-0">
+          <v-form v-model="arDetailsFormIsValid">
+            <v-row dense>
+              <v-col>
+                <v-text-field
+                  v-model="customerId"
+                  label="Accounts Receivable Customer ID"
+                  data-cy="update-customer-id"
+                  :error-messages="errors.customerId"
+                  :rules="formRules.generic"
+                ></v-text-field>
+              </v-col>
+              <v-col>
+                <v-text-field
+                  v-model="addressId"
+                  label="Accounts Receivable Address ID"
+                  data-cy="update-address-id"
+                  :error-messages="errors.addressId"
+                  :rules="formRules.generic"
+                ></v-text-field>
+              </v-col>
+            </v-row>
+          </v-form>
+        </v-card-text>
+        <v-card-actions class="d-flex justify-start pb-3">
+          <v-btn small text class="ml-2" color="secondary" @click="cancelARDetails">Close</v-btn>
+          <v-spacer></v-spacer>
+          <v-btn small text class="mr-2" color="secondary" @click="openARDetails">Clear</v-btn>
+          <v-btn small text class="mr-2" :disabled="!arDetailsFormIsValid" color="primary" @click="updateARDetails()">
+            Update
           </v-btn>
         </v-card-actions>
       </v-card>

--- a/src/components/organization/IFXOrganizationDetail.vue
+++ b/src/components/organization/IFXOrganizationDetail.vue
@@ -32,7 +32,7 @@ export default {
       showAddUserModal: false,
       showRevokeUserModal: false,
       showReactivateUserModal: false,
-      showAEditARModal: false,
+      showEditARModal: false,
       customerId: null,
       addressId: null,
       selected: [],
@@ -107,19 +107,19 @@ export default {
     openARDetails() {
       this.customerId = this.item.customerId
       this.addressId = this.item.addressId
-      this.showAEditARModal = true
+      this.showEditARModal = true
     },
     updateARDetails() {
       // We only have two fields, so we can just update them directly on the item and submit the whole org
       // instead of making a separate API call just for these details.
       this.item.customerId = this.customerId || null
       this.item.addressId = this.addressId || null
-      this.showAEditARModal = false
+      this.showEditARModal = false
     },
     cancelARDetails() {
       this.customerId = null
       this.addressId = null
-      this.showAEditARModal = false
+      this.showEditARModal = false
     },
     updateOrg(org) {
       this.item = org
@@ -228,12 +228,6 @@ export default {
           <v-col>
             <h2>Details</h2>
           </v-col>
-        </v-row>
-        <v-row dense justify="start">
-          <v-col class="ml-4 field-label">A/R Customer ID</v-col>
-          <v-col>
-            {{ item.customerId }}
-          </v-col>
           <v-col align="end">
             <v-tooltip top>
               <template v-slot:activator="{ on }">
@@ -253,12 +247,20 @@ export default {
             </v-tooltip>
           </v-col>
         </v-row>
+        <v-row dense justify="start">
+          <v-col class="ml-4 field-label">A/R Customer ID</v-col>
+          <v-col>
+            <span v-if="item.customerId">{{ item.customerId }}</span>
+            <span v-else class="grey--text text--darken-1">None</span>
+          </v-col>
+        </v-row>
         <v-row dense>
           <v-col class="ml-4 field-label">A/R Address ID</v-col>
           <v-col>
-            {{ item.addressId }}
+            <span v-if="item.addressId">{{ item.addressId }}</span>
+            <span v-else class="grey--text text--darken-1">None</span>
           </v-col>
-          <v-col>&nbsp;</v-col>
+          <!-- <v-col>&nbsp;</v-col> -->
         </v-row>
       </v-col>
     </v-row>
@@ -454,14 +456,14 @@ export default {
         </v-card-actions>
       </v-card>
     </v-dialog>
-    <v-dialog v-model="showAEditARModal" v-if="showAEditARModal" max-width="600px" persistent>
+    <v-dialog v-model="showEditARModal" v-if="showEditARModal" max-width="600px" persistent>
       <v-card>
         <v-card-title>
           Change A/R Details
           <v-spacer></v-spacer>
           <v-tooltip top>
             <template v-slot:activator="{ on, attrs }">
-              <v-btn icon small @click="showAEditARModal = false" data-cy="ar-dialog-close" v-on="on" v-bind="attrs">
+              <v-btn icon small @click="showEditARModal = false" data-cy="ar-dialog-close" v-on="on" v-bind="attrs">
                 <v-icon>mdi-close</v-icon>
               </v-btn>
             </template>
@@ -476,7 +478,7 @@ export default {
                   v-model="customerId"
                   label="Accounts Receivable Customer ID"
                   data-cy="update-customer-id"
-                  :error-messages="errors.customerId"
+                  :error-messages="errors.application_key"
                   :rules="formRules.generic"
                 ></v-text-field>
               </v-col>
@@ -485,7 +487,7 @@ export default {
                   v-model="addressId"
                   label="Accounts Receivable Address ID"
                   data-cy="update-address-id"
-                  :error-messages="errors.addressId"
+                  :error-messages="errors.application_key"
                   :rules="formRules.generic"
                 ></v-text-field>
               </v-col>
@@ -495,7 +497,7 @@ export default {
         <v-card-actions class="d-flex justify-start pb-3">
           <v-btn small text class="ml-2" color="secondary" @click="cancelARDetails">Close</v-btn>
           <v-spacer></v-spacer>
-          <v-btn small text class="mr-2" color="secondary" @click="openARDetails">Clear</v-btn>
+          <v-btn small text class="mr-2" color="secondary" @click="openARDetails">Reset</v-btn>
           <v-btn small text class="mr-2" :disabled="!arDetailsFormIsValid" color="primary" @click="updateARDetails()">
             Update
           </v-btn>

--- a/src/components/organization/IFXOrganizationDetail.vue
+++ b/src/components/organization/IFXOrganizationDetail.vue
@@ -479,7 +479,6 @@ export default {
                   label="Accounts Receivable Customer ID"
                   data-cy="update-customer-id"
                   :error-messages="errors.application_key"
-                  :rules="formRules.generic"
                 ></v-text-field>
               </v-col>
               <v-col>
@@ -488,7 +487,6 @@ export default {
                   label="Accounts Receivable Address ID"
                   data-cy="update-address-id"
                   :error-messages="errors.application_key"
-                  :rules="formRules.generic"
                 ></v-text-field>
               </v-col>
             </v-row>


### PR DESCRIPTION
This PR allows the user to edit A/R Details (Customer ID and Address ID) in the Organization Detail page; like other sections of that page, the change isn't saved until the user clicks "Save." We do this via a dialog that pops up and then, when new values are entered and the user clicks "Update", are updated.

Also, a variable name change that was supposed to go into a previous PR in `IFXCalendarList` is included here.