### PR TITLE
Organization rate display on organization list page

### DIFF
--- a/src/api/IFXAPI.js
+++ b/src/api/IFXAPI.js
@@ -568,6 +568,9 @@ export default class IFXAPIService {
       newOrgData.contacts = []
       newOrgData.users = []
       newOrgData.organization_rates = []
+      if (decompose) {
+        console.log('Decomposing organization data for caching:', newOrgData)
+      }
 
       // Check if incoming orgData has contacts
       if (orgData.contacts && orgData.contacts.length) {

--- a/src/api/IFXAPI.js
+++ b/src/api/IFXAPI.js
@@ -568,9 +568,6 @@ export default class IFXAPIService {
       newOrgData.contacts = []
       newOrgData.users = []
       newOrgData.organization_rates = []
-      if (decompose) {
-        console.log('Decomposing organization data for caching:', newOrgData)
-      }
 
       // Check if incoming orgData has contacts
       if (orgData.contacts && orgData.contacts.length) {

--- a/src/components/organization/IFXOrganizationDetail.vue
+++ b/src/components/organization/IFXOrganizationDetail.vue
@@ -208,7 +208,7 @@ export default {
             <h2>Details</h2>
           </v-col>
         </v-row>
-        <v-row dense justify="start">
+        <v-row dense justify="start" v-if="item.customerId">
           <v-col class="ml-4 field-label">
             A/R Customer ID
           </v-col>
@@ -219,7 +219,7 @@ export default {
             &nbsp;
           </v-col>
         </v-row>
-        <v-row dense>
+        <v-row dense v-if="item.addressId">
           <v-col class="ml-4 field-label">
             A/R Address ID
           </v-col>

--- a/src/components/organization/IFXOrganizationList.vue
+++ b/src/components/organization/IFXOrganizationList.vue
@@ -39,9 +39,19 @@ export default {
     },
   },
   methods: {
-    onfs(slug){
+    onfs(slug) {
       return this.$options.filters.orgNameFromSlug(slug)
-    }
+    },
+    displayOrgRates(orgRates) {
+      return orgRates.map((r) => {
+        const startDate = r.startDate ? new Date(r.startDate) : null
+        const endDate = r.endDate ? new Date(r.endDate) : null
+        const now = new Date()
+        const isActive = (!startDate || startDate <= now) && (!endDate || endDate >= now)
+        const rateName = r.rate.name
+        return isActive ? rateName : ''
+      }).join(', ')
+    },
     getSetItems() {
       // TODO: make this consistent, no api endpoint should be returning .data
       return (
@@ -105,6 +115,9 @@ export default {
     >
       <template v-slot:parents="{ item }">
         {{ item.parents ? item.parents.map((p) => onfs(p)).join(', ') : '' }}
+      </template>
+      <template v-slot:rate="{ item }">
+        {{ item.organizationRates ? displayOrgRates(item.organizationRates) : '' }}
       </template>
     </IFXItemDataTable>
     <slot name="extra-content"></slot>

--- a/src/components/organization/IFXOrganizationList.vue
+++ b/src/components/organization/IFXOrganizationList.vue
@@ -39,6 +39,9 @@ export default {
     },
   },
   methods: {
+    onfs(slug){
+      return this.$options.filters.orgNameFromSlug(slug)
+    }
     getSetItems() {
       // TODO: make this consistent, no api endpoint should be returning .data
       return (
@@ -99,7 +102,11 @@ export default {
       :itemType="itemType"
       :loading="isLoading"
       @update:selected="updateSelected"
-    />
+    >
+      <template v-slot:parents="{ item }">
+        {{ item.parents ? item.parents.map((p) => onfs(p)).join(', ') : '' }}
+      </template>
+    </IFXItemDataTable>
     <slot name="extra-content"></slot>
   </v-container>
 </template>


### PR DESCRIPTION
Adding a slot for organization rates on the organization list table.  They will be displayed if currently active (within the start and end date)
Also, show only organization name for parents
Don't display A/R fields unless occupied