### PR TITLE
Limit users from editing their own user page

### DIFF
--- a/src/components/user/IFXUserDetail.vue
+++ b/src/components/user/IFXUserDetail.vue
@@ -259,7 +259,7 @@ export default {
       return this.hasItemChanged()
     },
     isUserInfoEdittable() {
-      return this.item && this.item.username && !!this.item.ifxid && !this.djangoEditOnly
+      return this.item && this.item.username && !!this.item.ifxid && !this.djangoEditOnly && this.$api.auth.can('edit-users', this.$api.authUser)
     },
     userCategories() {
       return this.item.userFiles?.reduce((acc, file) => {


### PR DESCRIPTION
For NICE, we want users to be able to review their information on the user detail page, but don't want them to edit.  By default, this will allow only admins to edit users.