### PR TITLE
Change when the test-tube icon show up in the calendar popup

### DIFF
--- a/src/components/calendar/IFXCalendarList.vue
+++ b/src/components/calendar/IFXCalendarList.vue
@@ -1589,7 +1589,7 @@ export default {
                   >
                     mdi-minus-circle
                   </v-icon>
-                  <v-icon color="blue darken-2" class="mb-1 ml-2" v-if="!selectedEvent.reservation.approved">
+                  <v-icon color="blue darken-2" class="mb-1 ml-2" v-if="selectedEvent.reservation.trial">
                     mdi-test-tube
                   </v-icon>
                 </v-toolbar-title>

--- a/src/components/calendar/IFXCalendarList.vue
+++ b/src/components/calendar/IFXCalendarList.vue
@@ -1589,7 +1589,7 @@ export default {
                   >
                     mdi-minus-circle
                   </v-icon>
-                  <v-icon color="blue darken-2" class="mb-1 ml-2" v-if="selectedEvent.reservation.trial">
+                  <v-icon color="blue darken-2" class="mb-1 ml-2" v-if="useTrial && selectedEvent.reservation.trial">
                     mdi-test-tube
                   </v-icon>
                 </v-toolbar-title>


### PR DESCRIPTION
This PR changes when the test-tube icon shows up on the calendar popup.  Currently, it is displayed for unapproved reservations in the calendar but for trial/pilot reservations on the Reservation List page; this has now been changed to always display it for trial/pilot reservations.

This is in the context of the new-ish feature where, if the user uses an expense code that will have expired when their reservation time starts, we mark the reservation "unapproved." Now there is no way to see those reservations without opening them.