### PR TITLE
BauerCAT account request tweaks

### DIFF
--- a/src/components/request/IFXAccountRequestDetail.vue
+++ b/src/components/request/IFXAccountRequestDetail.vue
@@ -171,6 +171,7 @@ export default {
         .catch((error) => {
           console.log(error)
           this.showMessage(error)
+          clearInterval(me.refresh_timer)
         })
     },
   },

--- a/src/components/request/IFXAccountRequestTrackDetail.vue
+++ b/src/components/request/IFXAccountRequestTrackDetail.vue
@@ -14,6 +14,7 @@ import DisplayTermsAndConditions from './IFXDisplayTermsAndConditions'
 import DisplayAffiliations from './IFXDisplayAffiliations'
 import DisplayEnteredAffiliation from './IFXDisplayEnteredAffiliation'
 import DisplaySimpleText from './IFXDisplaySimpleText'
+import DisplayBillingContact from './IFXDisplayBillingContact'
 
 export default {
   name: 'IFXAccountRequestTrackDetail',
@@ -39,6 +40,7 @@ export default {
     DisplayAffiliations,
     DisplayEnteredAffiliation,
     DisplaySimpleText,
+    DisplayBillingContact,
   },
   data() {
     return {
@@ -98,7 +100,7 @@ export default {
               @change="updateData()"
             ></component>
             <component
-              v-else-if="['primary_affiliation'].includes(field)"
+              v-else-if="['primary_affiliation', 'billing_contact'].includes(field)"
               :is="accountRequestData.tracks[track].fields[field].display_component"
               :data="accountRequestData"
             ></component>

--- a/src/components/request/IFXDisplayBillingContact.vue
+++ b/src/components/request/IFXDisplayBillingContact.vue
@@ -1,0 +1,28 @@
+<script>
+export default {
+  name: 'IFXDisplayBillingContact',
+  props: ['data'],
+}
+</script>
+<template>
+  <v-row v-if="data" dense>
+    <v-col>
+      <v-row dense>
+        <v-col>
+          {{ data.billing_contact.name}}
+        </v-col>
+      </v-row>
+      <v-row dense>
+        <v-col>
+          {{ data.billing_contact.email}}
+        </v-col>
+      </v-row>
+      <v-row dense>
+        <v-col class="text-pre-wrap">
+          {{ data.billing_contact.address}}
+        </v-col>
+      </v-row>
+    </v-col>
+  </v-row>
+</template>
+<style scoped></style>

--- a/src/components/request/IFXDisplayEnteredAffiliation.vue
+++ b/src/components/request/IFXDisplayEnteredAffiliation.vue
@@ -61,6 +61,12 @@ export default {
             </v-flex>
           </v-layout>
         </v-flex>
+        <v-flex v-else-if="data && data.person.primary_affiliation">
+          {{ data.person.primary_affiliation }}
+        </v-flex>
+        <v-flex v-else>
+          No affiliation entered
+        </v-flex>
       </v-layout>
     </v-flex>
   </v-layout>

--- a/src/entrypoint.js
+++ b/src/entrypoint.js
@@ -166,6 +166,7 @@ import IFXDisplayEnteredAffiliation from '@/components/request/IFXDisplayEntered
 import IFXDisplaySimpleText from '@/components/request/IFXDisplaySimpleText'
 import IFXRequestCommentList from '@/components/request/IFXRequestCommentList'
 import IFXRequestList from '@/components/request/IFXRequestList'
+import IFXDisplayBillingContact from '@/components/request/IFXDisplayBillingContact'
 
 // These components/mixins must be import individually in host application
 export {
@@ -273,6 +274,7 @@ export {
   IFXDisplayAffiliations,
   IFXDisplayEnteredAffiliation,
   IFXDisplaySimpleText,
+  IFXDisplayBillingContact,
   IFXRequestCommentList,
   IFXRequestList,
   IFXLabBillingSummaryList,


### PR DESCRIPTION
Setup IFXDisplayBillingContact for showing billing contact data; used in BauerCAT
Updated entered affiliation to show the primary affiliation if it's set, rather than the entered data
Clear the interval for account request detail page updates if there is an error