### PR TITLE
Have `IFXItemDataTable` pass through the `item-selected` event

### DIFF
--- a/src/components/item/IFXItemDataTable.vue
+++ b/src/components/item/IFXItemDataTable.vue
@@ -100,8 +100,9 @@ export default {
     },
     // Method for handling item select/deselect
     itemSelected(event) {
-      this.$emit('item-selected', event.item, event.value)
-    },
+      this.$emit('item-selected', event)
+      return null
+    }
   },
   computed: {
     // Checks if user has specified a click event for the row

--- a/src/components/item/IFXItemDataTable.vue
+++ b/src/components/item/IFXItemDataTable.vue
@@ -98,6 +98,10 @@ export default {
       }
       return null
     },
+    // Method for handling item select/deselect
+    itemSelected(event) {
+      this.$emit('item-selected', event.item, event.value)
+    },
   },
   computed: {
     // Checks if user has specified a click event for the row
@@ -162,6 +166,7 @@ export default {
     :hide-default-footer="hideDefaultFooter"
     :loading="loading"
     @update:page="pageChange"
+    @item-selected="itemSelected"
     :page="currentPage"
   >
     <!-- Loops through all headers and either uses a specified named slot or the data table cell component -->


### PR DESCRIPTION
This PR allows the `IFXItemDataTable` to pass the `item-selected` event from the underlying `v-data-table` through to whomever instantiated it. This is needed for a BauerCat feature.