### PR TITLE
Onboard url and affiliations fix

### DIFF
--- a/src/components/request/IFXAccountRequestDetail.vue
+++ b/src/components/request/IFXAccountRequestDetail.vue
@@ -179,6 +179,12 @@ export default {
     django_admin_url: function () {
       return `${this.$api.urls.DJANGO_ADMIN_ROOT}ifxrequest/request/${this.request.id}/change/`
     },
+    onboardRequestUrl: function () {
+      if (!this.$api.urls.ONBOARD_REQUEST_URL_ROOT || !this.request.continuationKey) {
+        return ''
+      }
+      return `${this.$api.urls.ONBOARD_REQUEST_URL_ROOT}?key=${this.request.continuationKey}`
+    },
   },
   beforeRouteLeave(to, from, next) {
     clearInterval(this.refresh_timer)
@@ -256,7 +262,7 @@ export default {
               <v-flex xs6>
                 <v-layout row wrap justify-start align-center>
                   <v-flex shrink class="expiration-date-label">
-                    Onboard request
+                    <a :href="onboardRequestUrl">Onboard request</a>
                     <span v-if="requestExpired()">expired</span>
                     <span v-else>expires</span>
                   </v-flex>

--- a/src/components/request/IFXAccountRequestDetail.vue
+++ b/src/components/request/IFXAccountRequestDetail.vue
@@ -262,7 +262,7 @@ export default {
               <v-flex xs6>
                 <v-layout row wrap justify-start align-center>
                   <v-flex shrink class="expiration-date-label">
-                    <a :href="onboardRequestUrl">Onboard request</a>
+                    <a :href="onboardRequestUrl">Onboard request </a>
                     <span v-if="requestExpired()">expired</span>
                     <span v-else>expires</span>
                   </v-flex>

--- a/src/components/request/IFXAccountRequestTrackDetail.vue
+++ b/src/components/request/IFXAccountRequestTrackDetail.vue
@@ -100,7 +100,7 @@ export default {
               @change="updateData()"
             ></component>
             <component
-              v-else-if="['primary_affiliation', 'billing_contact'].includes(field)"
+              v-else-if="['primary_affiliation', 'billing_contact', 'affiliations'].includes(field)"
               :is="accountRequestData.tracks[track].fields[field].display_component"
               :data="accountRequestData"
             ></component>

--- a/src/components/request/IFXDisplayAffiliations.vue
+++ b/src/components/request/IFXDisplayAffiliations.vue
@@ -40,7 +40,7 @@ export default {
             <v-flex>
               <v-layout row>
                 <v-flex xs4>Approvers</v-flex>
-                <v-flex v-if="data.approver_contacts.length > 0" xs7>
+                <v-flex v-if="data.approver_contacts && data.approver_contacts.length > 0" xs7>
                   <span v-for="(approver, index) in data.approver_contacts" :key="index">
                     <a :href="`mailto:${approver}`">{{ approver }}</a>
                     <span v-if="index < data.approver_contacts.length - 1">,&nbsp;</span>


### PR DESCRIPTION
Add a URL to the onboard request in the account request detail.  Facility admin can uncheck an onboarding step and then go to the onboard request directly to fix.

Fix the IFXDisplayAffiliations component so that a lack of approver contacts won't prevent affiliation display