### PR TITLE
Extend billing record `getList` params

### DIFF
--- a/src/api/IFXAPI.js
+++ b/src/api/IFXAPI.js
@@ -931,10 +931,7 @@ export default class IFXAPIService {
     const api = this.genericAPI(baseURL, IFXLogChannel)
     api.getSubscriberEmails = async (channelIds) => {
       const url = this.urls.GET_SUBSCRIBER_EMAILS
-      return this.axios.post(
-        url,
-        { channel_ids: channelIds }
-      ).then((res) => res.data)
+      return this.axios.post(url, { channel_ids: channelIds }).then((res) => res.data)
     }
     return api
   }
@@ -1210,8 +1207,8 @@ export default class IFXAPIService {
     const decomposeFunc = (billingRecord) => createFunc(billingRecord, true)
     const api = this.genericAPI(baseURL, null, createFunc, decomposeFunc)
 
-    api.getList = async (invoice_prefix, month = null, year = null, organization = null) => {
-      const params = { invoice_prefix, month, year, organization }
+    api.getList = async (invoice_prefix, month = null, year = null, organization = null, extraParams = {}) => {
+      const params = { invoice_prefix, month, year, organization, ...extraParams }
       const url = this.urls.BILLING_RECORD_LIST
       return this.axios.get(url, { params }).then((res) => Promise.all(res.data.map((data) => createFunc(data))))
     }
@@ -1421,9 +1418,7 @@ export default class IFXAPIService {
     const createFunc = (productBillingSummaryData, decompose = false) => {
       const newProductBillingSummaryData = cloneDeep(productBillingSummaryData) || {}
       // If decomposing, do not create a new object
-      return decompose
-        ? newProductBillingSummaryData
-        : new ProductBillingSummary(newProductBillingSummaryData)
+      return decompose ? newProductBillingSummaryData : new ProductBillingSummary(newProductBillingSummaryData)
     }
     const decomposeFunc = (newProductBillingSummaryData) => createFunc(newProductBillingSummaryData, true)
     return this.genericAPI(baseURL, ProductBillingSummary, createFunc, decomposeFunc)

--- a/src/api/IFXAPI.js
+++ b/src/api/IFXAPI.js
@@ -1211,8 +1211,9 @@ export default class IFXAPIService {
     const decomposeFunc = (billingRecord) => createFunc(billingRecord, true)
     const api = this.genericAPI(baseURL, null, createFunc, decomposeFunc)
 
-    api.getList = async (invoice_prefix, month = null, year = null, organization = null, extraParams = {}) => {
-      const params = { invoice_prefix, month, year, organization, ...extraParams }
+    api.getList = async (invoice_prefix, month = null, year = null, organization = null, extraParams = null) => {
+      const extra = extraParams && typeof extraParams === 'object' ? extraParams : {}
+      const params = { ...extra, invoice_prefix, month, year, organization }
       const url = this.urls.BILLING_RECORD_LIST
       return this.axios.get(url, { params }).then((res) => Promise.all(res.data.map((data) => createFunc(data))))
     }


### PR DESCRIPTION
This PR adds `extraParams` to the `BillingRecord` `getList` API call; this allows extra params to be passed to the back-end to be added to the query. It is needed for NICE "Search Bills" feature.